### PR TITLE
Handle null response +semver: minor

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -21,7 +21,7 @@ function handleItem($pullRequest, $isRetry = false)
     $token = generateInstallationToken($pullRequest->InstallationId, $pullRequest->RepositoryName);
     $metadata = createMetadata($token, $pullRequest, $config);
     $pullRequestResponse = doRequestGitHub($metadata["token"], $metadata["pullRequestUrl"], null, "GET");
-    $pulRequestResponse->ensureSuccessStatus();
+    $pullRequestResponse->ensureSuccessStatus();
     $pullRequestUpdated = json_decode($pullRequestResponse->getBody());
 
     if ($pullRequestUpdated->state === "closed") {

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -21,6 +21,7 @@ function handleItem($pullRequest, $isRetry = false)
     $token = generateInstallationToken($pullRequest->InstallationId, $pullRequest->RepositoryName);
     $metadata = createMetadata($token, $pullRequest, $config);
     $pullRequestResponse = doRequestGitHub($metadata["token"], $metadata["pullRequestUrl"], null, "GET");
+    $pulRequestResponse->ensureSuccessStatus();
     $pullRequestUpdated = json_decode($pullRequestResponse->getBody());
 
     if ($pullRequestUpdated->state === "closed") {


### PR DESCRIPTION
### **User description**
## 📑 Description
Handle null GitHub API response getting pull request updated.
```
PHP Deprecated:  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /home/zerocool/cronJobs/gstraccini-bot/pullRequests.php on line 24
```

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Added a call to `ensureSuccessStatus()` to validate the GitHub API response.
- This change prevents issues related to null responses from the API.
- Improves error handling and robustness of the pull request processing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Enhance GitHub API response handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pullRequests.php
<li>Added a check to ensure the GitHub API response is successful.<br> <li> Prevents potential errors when handling null responses.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-service/pull/805/files#diff-84c6d7877dee9ad42a29924c3cda6620ed15394ba479a7f90dfd17eeabd65a40">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for GitHub API pull request responses
	- Added validation to ensure successful API request status before processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->