### PR TITLE
Flag pull request as closed

### DIFF
--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -89,6 +89,24 @@ function finalizeProcessing($tableName, $sequence): bool
     return $succeeded;
 }
 
+function closePullRequest($sequence): bool
+{
+    $mysqli = connectToDatabase();
+
+    $sql = "UPDATE github_pull_requets SET State = 'CLOSED'  WHERE Sequence = ? AND State = 'OPEN'";
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param("i", $sequence);
+    $succeeded = false;
+
+    if ($stmt->execute()) {
+        $succeeded = $stmt->affected_rows === 1;
+    }
+
+    $stmt->close();
+    $mysqli->close();
+    return $succeeded;
+}
+
 function upsertPullRequest($pullRequest)
 {
     $mysqli = connectToDatabase();

--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -93,7 +93,7 @@ function closePullRequest($sequence): bool
 {
     $mysqli = connectToDatabase();
 
-    $sql = "UPDATE github_pull_requets SET State = 'CLOSED'  WHERE Sequence = ? AND State = 'OPEN'";
+    $sql = "UPDATE github_pull_requests SET State = 'CLOSED'  WHERE Sequence = ? AND State = 'OPEN'";
     $stmt = $mysqli->prepare($sql);
     $stmt->bind_param("i", $sequence);
     $succeeded = false;

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -35,7 +35,7 @@ function handleItem($pullRequest, $isRetry = false)
         if ($pullRequest->State !== "CLOSED") {
             closePullRequest($pullRequest->Sequence);
         }
-        
+
         return;
     }
 

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -32,6 +32,10 @@ function handleItem($pullRequest, $isRetry = false)
 
     if ($pullRequestUpdated->state != "open") {
         echo "PR State: {$pullRequestUpdated->state} ⛔\n";
+        if ($pullRequest->State !== "CLOSED") {
+            closePullRequest($pullRequest->Sequence);
+        }
+        
         return;
     }
 


### PR DESCRIPTION
### **User description**
## 📑 Description
Flag pull request as closed

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced a new function `closePullRequest` to update the state of pull requests to 'CLOSED'.
- Enhanced the PR handling logic to automatically close pull requests that are not in the "open" state.
- Improved database interaction with prepared statements for security.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.php</strong><dd><code>Implement closePullRequest function for PR state management</code></dd></summary>
<hr>

Src/lib/database.php
<li>Added <code>closePullRequest</code> function to update pull request state to <br>'CLOSED'.<br> <li> Prepared SQL statement to safely execute the update.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-service/pull/833/files#diff-e961f04c095d0578c47b18c7a257ec9d4fcabccc68370272dccc7263150c0fef">+18/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Update PR handling to close PRs when necessary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/pullRequests.php
<li>Integrated <code>closePullRequest</code> function call when PR state is not "open".<br> <li> Ensured proper handling of pull request state updates.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-service/pull/833/files#diff-a02ee044998cfd579cf9d812f74b51f079e912308e6ce6d9c1337620894ec463">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automatic update that marks pull requests as closed when they reach a non-open state.
	- Enhanced pull request processing to ensure a consistent and reliable status transition for better lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->