### PR TITLE
Add commit identification to recreate comment +semver: minor

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -444,10 +444,11 @@ function resolveConflicts($metadata, $pullRequest, $pullRequestUpdated)
         }
         echo "State: " . $pullRequestUpdated->mergeable_state . " - Resolve conflicts - Recreate via bot - Sender: " . $pullRequest->Sender . " ☢️\n";
 
+        $prefix = "<!--GStraccini:{$pullRequestUpdated->head->ref}-->\n";
         if ($pullRequest->Sender === "dependabot[bot]") {
-            $comment = array("body" => "@dependabot recreate");
+            $comment = array("body" => "{$prefix}@dependabot recreate");
         } else {
-            $comment = array("body" => "@depfu recreate");
+            $comment = array("body" => "{$prefix}@depfu recreate");
         }
 
         doRequestGitHub($metadata["userToken"], $metadata["commentsUrl"], $comment, "POST");


### PR DESCRIPTION
### **User description**
## 📑 Description
Add commit identification to recreate comment

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced a commit identification prefix in the recreate comment for better traceability.
- Updated the comment structure for `dependabot` and `depfu` to include the commit reference.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Enhance comment recreation with commit identification</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pullRequests.php
<li>Added a commit identification prefix to the recreate comment.<br> <li> Modified the comment body for both <code>dependabot</code> and <code>depfu</code> users.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-service/pull/863/files#diff-84c6d7877dee9ad42a29924c3cda6620ed15394ba479a7f90dfd17eeabd65a40">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bot-triggered conflict resolution comments now include a unique HTML comment prefix with the pull request's branch reference for enhanced identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->