### PR TITLE
Check for previous comments for recreate the PR

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -498,6 +498,33 @@ function findCommentByContent($metadata, $pullRequestUpdated, $prefix): bool
     return false;
 }
 
+/**
+ * Updates a pull request branch if it is behind the base branch.
+ *
+ * This function compares the base and head references of a pull request to determine
+ * how many commits the head is behind. If the branch is behind, it sends a request
+ * to update the pull request branch using the GitHub API.
+ *
+ * Diagnostic output is printed to indicate whether an update was needed and performed,
+ * including mergeable state, number of commits behind, and sender info.
+ *
+ * @param array $metadata An associative array containing metadata required to perform the update.
+ *                        Must include:
+ *                        - 'token' (string): The GitHub API token.
+ *                        - 'compareUrl' (string): The API base URL for comparing refs.
+ *                        - 'pullRequestUrl' (string): The API URL for the pull request being updated.
+ * @param object $pullRequestUpdated An object representing the updated pull request data.
+ *                                   Required properties:
+ *                                   - base->ref (string): The base branch name.
+ *                                   - head->ref (string): The head branch name.
+ *                                   - head->sha (string): The SHA of the head commit.
+ *                                   - mergeable_state (string): The pull request's mergeable state.
+ *                                   - user->login (string): The GitHub username of the sender.
+ *
+ * @return void
+ *
+ * @throws SomeException If the `doRequestGitHub` function fails or returns an unexpected response.
+ */
 function updateBranch($metadata, $pullRequestUpdated)
 {
     $baseRef = urlencode($pullRequestUpdated->base->ref);

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -464,10 +464,28 @@ function resolveConflicts($metadata, $pullRequest, $pullRequestUpdated)
     }
 }
 
+/**
+ * Checks if a comment containing a specific prefix exists in a pull request.
+ *
+ * This function fetches the first page of comments from a given pull request's
+ * `commentsUrl` and searches through each comment to determine whether any
+ * contains the specified prefix in its body.
+ *
+ * @param array  $metadata            An associative array containing metadata about the pull request.
+ *                                    Must include:
+ *                                    - 'commentsUrl' (string): The GitHub API URL to fetch comments.
+ *                                    - 'token' (string): The GitHub API token used for authentication.
+ * @param bool   $pullRequestUpdated  A boolean indicating if the pull request was updated. *(Currently unused in logic.)*
+ * @param string $prefix              The string prefix to search for within the comment bodies.
+ *
+ * @return bool  Returns `true` if a comment containing the prefix is found, `false` otherwise.
+ *
+ * @throws SomeException              If the `doRequestGitHub` function or response status fails (based on actual implementation).
+ */
 function findCommentByContent($metadata, $pullRequestUpdated, $prefix): bool
 {
     $url = "{$metadata["commentsUrl"]}?per_page=100&page=1";
-    $commentsResponse = doRequestGitHub($metada["token"], $url, null, "GET");
+    $commentsResponse = doRequestGitHub($metadata["token"], $url, null, "GET");
     $commentsResponse->ensureSuccessStatus();
     $comments = json_decode($commentsResponse->getBody());
 

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -451,7 +451,7 @@ function resolveConflicts($metadata, $pullRequest, $pullRequestUpdated)
             echo "State: " . $pullRequestUpdated->mergeable_state . " - Resolve conflicts - Already requested to recreate - Sender: " . $pullRequest->Sender . " ⚠️\n";
             return;
         }
-        
+
         if ($pullRequest->Sender === "dependabot[bot]") {
             $comment = array("body" => "{$prefix}@dependabot recreate");
         } else {
@@ -464,14 +464,14 @@ function resolveConflicts($metadata, $pullRequest, $pullRequestUpdated)
     }
 }
 
-function findCommentByContent($metadata, $pullRequestUpdated, $prefix) : bool
+function findCommentByContent($metadata, $pullRequestUpdated, $prefix): bool
 {
     $url = "{$metadata["commentsUrl"]}?per_page=100&page=1";
     $commentsResponse = doRequestGitHub($metada["token"], $url, null, "GET");
     $commentsResponse->ensureSuccessStatus();
     $comments = json_decode($commentsResponse->getBody());
 
-    foreach ($comments as $comment){
+    foreach ($comments as $comment) {
         if (strpos($comment->body, $prefix) !== false) {
             return true;
         }


### PR DESCRIPTION
### **User description**
## 📑 Description
Check for previous comments for recreate the PR

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced a new function `findCommentByContent` to verify if a specific comment already exists in the pull request.
- Updated the `resolveConflicts` function to prevent duplicate requests for recreation if a comment is found.
- Changed the comment prefix to include the SHA of the head instead of the branch reference for better identification.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Enhance pull request conflict resolution with comment checking</code></dd></summary>
<hr>

src/pullRequests.php
<li>Added a new function <code>findCommentByContent</code> to check for existing <br>comments.<br> <li> Updated the <code>resolveConflicts</code> function to utilize the new <br>comment-checking logic.<br> <li> Changed the comment prefix to use the SHA instead of the branch <br>reference.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-service/pull/864/files#diff-84c6d7877dee9ad42a29924c3cda6620ed15394ba479a7f90dfd17eeabd65a40">+24/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conflict resolution to prevent duplicate recreate requests in pull request comments.
  - Ensured that only one recreate command is posted per conflict, reducing unnecessary notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->