### PR TITLE
[CHORE] Add Docker health checks for all services +semver: minor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   www:
     container_name: www
@@ -11,6 +9,12 @@ services:
       - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
     networks:
       - default
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
 
   database:
     container_name: database
@@ -27,6 +31,12 @@ services:
       - my-db:/var/lib/mysql
     networks:
       - default
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   queue:
     container_name: queue
@@ -37,6 +47,12 @@ services:
     restart: unless-stopped
     networks:
       - default
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_port_listener", "amqp"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
 
   mailhog:
     image: mailhog/mailhog:latest
@@ -45,6 +61,12 @@ services:
       - "8025:8025"
     networks:
       - default
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8025"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
 
 volumes:
   my-db:


### PR DESCRIPTION
### **User description**
## 📑 Description

This pull request adds Docker `healthcheck` definitions to all services in the `docker-compose.yml` file to improve container observability and orchestration reliability. Each service now includes a tailored health check command, interval, timeout, retry count, and start period:

- **www**: Checks availability of the default web page using `curl`.
- **database**: Pings the MySQL server using `mysqladmin`.
- **queue**: Verifies RabbitMQ is listening on the AMQP port.
- **mailhog**: Checks availability of the MailHog web UI.

These health checks will allow Docker and dependent services to respond more intelligently to unhealthy containers.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced Docker `healthcheck` definitions for all services in `docker-compose.yml`.
- Each service now has a tailored health check command, interval, timeout, retry count, and start period.
- Enhances container observability and orchestration reliability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add health checks for all services in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml
<li>Added health checks for the <code>www</code> service using <code>curl</code>.<br> <li> Implemented health checks for the <code>database</code> service using <code>mysqladmin</code>.<br> <li> Included health checks for the <code>queue</code> service using <br><code>rabbitmq-diagnostics</code>.<br> <li> Established health checks for the <code>mailhog</code> service using <code>curl</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-service/pull/882/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+24/-2</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added health checks to all services in the environment, enabling active monitoring of service readiness and liveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->