### PR TITLE
Add `simplemd` format

### DIFF
--- a/Src/api/v1/commands.php
+++ b/Src/api/v1/commands.php
@@ -60,6 +60,21 @@ function generateMarkdown($commands)
 }
 
 /**
+ * Generates simple markdown documentation for the commands
+ *
+ * @param array $commands Array of command objects
+ * @return string Formatted markdown
+ */
+function generateSimpleMarkdown($commands)
+{
+    $output = "## Available Commands\n\n";
+    foreach ($commands as $command) {
+        $output .= "- **" . $command['command'] . "**: " . $command['description'] . "\n";
+    }    
+    return $output;
+}
+
+/**
  * Generates HTML documentation for the commands
  *
  * Creates a complete HTML page with styling and formatted command details
@@ -97,7 +112,7 @@ function generateHTML($commands)
             $output .= " <span class='tag pr-required'>PR Required</span>";
         }
         if (isset($command['dev']) && $command['dev']) {
-            $output .= " <span class='tag dev-command'>Developer</span>";
+            $output .= " <span class='tag dev-command'>NOT IMPLEMENTED</span>";
         }
 
         $output .= "</h3>\n";
@@ -163,6 +178,10 @@ switch ($format) {
     case 'text':
         header('Content-Type: text/plain');
         echo generateSimpleList($commands);
+        break;
+    case 'simplemd':
+        header('Content-Type: text/markdown');
+        echo generateSimpleMarkdown($commands);
         break;
     case 'markdown':
     default:

--- a/Src/api/v1/commands.php
+++ b/Src/api/v1/commands.php
@@ -9,10 +9,12 @@
  * - JSON
  *
  * Usage:
- *   /path/to/commands.php              # Default markdown output
- *   /path/to/commands.php?format=html  # HTML output
- *   /path/to/commands.php?format=text  # Simple text list
- *   /path/to/commands.php?format=json  # JSON output
+ *   /path/to/commands.php                  # Default markdown output
+ *   /path/to/commands.php?format=markdown  # Markdown output
+ *   /path/to/commands.php?format=simplemd  # Simple/tiny Markdown output
+ *   /path/to/commands.php?format=html      # HTML output
+ *   /path/to/commands.php?format=text      # Simple text list
+ *   /path/to/commands.php?format=json      # JSON output
  *
  * @author Guilherme Branco Stracini guilherme(at)guilhermebranco(dot)com(dot)br
  * @version 1.0

--- a/Src/api/v1/commands.php
+++ b/Src/api/v1/commands.php
@@ -70,7 +70,7 @@ function generateSimpleMarkdown($commands)
     $output = "## Available Commands\n\n";
     foreach ($commands as $command) {
         $output .= "- **" . $command['command'] . "**: " . $command['description'] . "\n";
-    }    
+    }
     return $output;
 }
 


### PR DESCRIPTION
## 📑 Description
Add `simplemd` fomrat

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a new simple markdown format option for generating command documentation

New Features:
- Introduce `simplemd` format to generate a lightweight markdown list of commands

Enhancements:
- Update HTML generation to replace 'Developer' tag with 'NOT IMPLEMENTED'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "simplemd" output format for command listings, providing a minimal Markdown list of commands and descriptions.
- **Documentation**
  - Updated usage examples to include the new "markdown" and "simplemd" output formats.
- **Style**
  - Changed the label for developer commands in the HTML output from "Developer" to "NOT IMPLEMENTED".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->