### PR TITLE
Remove Mergeable columns/fields

### DIFF
--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -107,29 +107,6 @@ function updateStateToClosedInTable($table, $sequence): bool
     return $succeeded;
 }
 
-function upsertPullRequestMergeable($prUpsert): void
-{
-    $mysqli = connectToDatabase();
-    $sql = "UPDATE github_pull_requests SET Mergeable = ?, MergeableState = ?, Merged = ? WHERE Sequence = ?";
-    $stmt = $mysqli->prepare($sql);
-
-    $mergeable = $prUpsert->Mergeable;
-    $mergeableState = $prUpsert->MergeableState;
-    $merged = $prUpsert->Merged;
-    $sequence = $prUpsert->Sequence;
-    $stmt->bind_param("isii", $mergeable, $mergeableState, $merged, $sequence);
-
-    if (!$stmt->execute()) {
-        $errorMessage = sprintf(
-            'Database execute failed: (%d) %s',
-            $stmt->errno,
-            $stmt->error
-        );
-        error_log($errorMessage);
-        throw new \RuntimeException($errorMessage);
-    }
-}
-
 function upsertPullRequest($pullRequest)
 {
     $mysqli = connectToDatabase();

--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -18,7 +18,7 @@ function connectToDatabase($isRetry = false)
         $mysqli->set_charset("utf8mb4");
 
         return $mysqli;
-    } catch(Exception $e) {
+    } catch (Exception $e) {
         if ($isRetry) {
             throw $e;
         }

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -25,8 +25,6 @@ function handleItem($pullRequest, $isRetry = false)
     $pullRequestResponse->ensureSuccessStatus();
     $pullRequestUpdated = json_decode($pullRequestResponse->getBody());
 
-    updateMergeable($pullRequest, $pullRequestUpdated);
-
     if ($pullRequestUpdated->state === "closed") {
         removeIssueWipLabel($metadata, $pullRequest);
         removeLabels($metadata, $pullRequestUpdated);

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -287,17 +287,6 @@ function checkForOtherPullRequests($metadata, $pullRequest)
     }
 }
 
-function updateMergeable($pullRequest, $pullRequestUpdated): void
-{
-    $prUpsert = new \stdClass();
-    $prUpsert->Sequence = $pullRequest->Sequence;
-    $prUpsert->Mergeable = $pullRequestUpdated->mergeable;
-    $prUpsert->MergeableState = $pullRequestUpdated->mergeable_state;
-    $prUpsert->Merged = $pullRequestUpdated->merged;
-    echo "Updating mergeable data of #{$pullRequestUpdated->number} - Sender: " . $pullRequest->Sender . " 🔄\n";
-    upsertPullRequestMergeable($prUpsert);
-}
-
 function triggerReview($pullRequest, $pullRequestPending)
 {
     $prUpsert = new \stdClass();


### PR DESCRIPTION
## 📑 Description
Remove Mergeable columns/fields

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Remove mergeability tracking fields and associated update logic from pullRequests.php

Enhancements:
- Remove the updateMergeable function and its associated upsert call
- Drop the Mergeable, MergeableState, and Merged properties from the pull request metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed internal handling and updating of pull request mergeable state during processing. No user-facing functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->