### PR TITLE
Use bot token instead of user token

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -258,7 +258,7 @@ function updatePullRequestDescription($metadata, $content)
 
     if (strpos($content, 'Please provide a description') !== false) {
         $comment = array("body" => $content);
-        doRequestGitHub($metadata["userToken"], $metadata["commentsUrl"], $comment, "POST");
+        doRequestGitHub($metadata["token"], $metadata["commentsUrl"], $comment, "POST");
     }
 }
 


### PR DESCRIPTION
## 📑 Description
Use bot token instead of user token

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Bug Fixes:
- Use the bot authentication token instead of the user token when posting pull request comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted authentication for posting comments on pull requests, which may affect the permissions or identity used when comments are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->