### PR TITLE
Remove awaiting triage label if all required reviewers have reviewed the pull request

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -181,7 +181,7 @@ function removeAwaitingTriageIfReviewed($metadata, $pullRequestUpdated, $collabo
     $labelToRemove = str_replace(" ", "%20", "🚦 awaiting triage");
     $url = $metadata["pullRequestUrl"] . "/labels/{$labelToRemove}";
     $response = doRequestGitHub($metadata["token"], $url, null, "DELETE");
-    
+
     if ($response->getStatusCode() < 300) {
         echo "Awaiting triage: Label removed - All reviewers have reviewed and last review is recent ✅\n";
     } else {
@@ -207,7 +207,7 @@ function getLastReviewTimestamp($metadata)
         return null;
     }
 
-    usort($reviews, function($a, $b) {
+    usort($reviews, function ($a, $b) {
         return strtotime($b->submitted_at) - strtotime($a->submitted_at);
     });
 
@@ -225,7 +225,7 @@ function getLastCommitTimestamp($metadata, $pullRequestUpdated)
 {
     $commitsUrl = $metadata["pullRequestUrl"] . "/commits";
     $commitsResponse = doRequestGitHub($metadata["token"], $commitsUrl, null, "GET");
-    
+
     if ($commitsResponse->getStatusCode() >= 300) {
         return isset($pullRequestUpdated->head->repo->pushed_at) ? $pullRequestUpdated->head->repo->pushed_at : null;
     }


### PR DESCRIPTION
## 📑 Description
Remove awaiting triage label if all required reviewers have reviewed the pull request

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Remove the “🚦 awaiting triage” label from pull requests once all required reviewers have submitted reviews that are more recent than the last commit.

New Features:
- Automatically remove the “🚦 awaiting triage” label when all required reviewers have reviewed and the last review is after the latest commit

Enhancements:
- Introduce removeAwaitingTriageIfReviewed to encapsulate label removal logic and helper functions to fetch the last review and commit timestamps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "🚦 awaiting triage" label is now automatically removed from pull requests once all required collaborators (excluding the sender) have reviewed and the latest review is after the last commit, provided the sender is not a collaborator.

* **Bug Fixes**
  * Improved accuracy in label management by ensuring labels reflect the current review status of pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->