### PR TITLE
[FEATURE] #1055 Add new command to run PHPCS autofix +semver: minor

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -771,6 +771,25 @@ function execute_npmLintFix($config, $metadata, $comment): void
     callWorkflow($config, $metadata, $comment, "npm-lint-fix.yml");
 }
 
+function execute_phpcs($config, $metadata, $comment): void
+{
+    preg_match(
+        "/@" . $config->botName . "\sphpcs(?:\s(\w+))?/",
+        $comment->CommentBody,
+        $matches
+    );
+    $parameters = array();
+
+    if (count($matches) === 2) {
+        $parameters["standard"] = $matches[1];
+    }
+
+    doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
+    $body = "Running [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) on this branch! :wrench:";
+    doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+    callWorkflow($config, $metadata, $comment, "phpcs-autofix.yml", $parameters);
+}
+
 function execute_prettier($config, $metadata, $comment): void
 {
     doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");

--- a/Src/config/commands.json
+++ b/Src/config/commands.json
@@ -205,6 +205,18 @@
         "requiresPullRequestOpen": true
     },
     {
+        "command": "phpcs",
+        "description": "Runs the [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) to detect violations of a defined coding standard (only for **PHP** projects).",
+        "parameters": [
+            {
+                "parameter": "standard",
+                "description": "The coding standard to use (e.g., PSR12, PSR2, WordPress). Ignored if a `phpcs.xml` config file exists in the repository. Defaults to `PSR12`.",
+                "required": false
+            }
+        ],
+        "requiresPullRequestOpen": true
+    },
+    {
         "command": "prettier",
         "description": "Formats the code using [Prettier](https://prettier.io).",
         "requiresPullRequestOpen": true


### PR DESCRIPTION
## 📑 Description
[FEATURE] #1055 Add new command to run PHPCS autofix +semver: minor

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

New Features:
- Introduce a new comment handler that parses an @bot phpcs command with an optional standard parameter and triggers the PHPCS autofix workflow.