### PR TITLE
Add ChangeRunner command handler

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -420,6 +420,32 @@ function execute_cargoClippy($config, $metadata, $comment): void
     callWorkflow($config, $metadata, $comment, "cargo-clippy.yml");
 }
 
+function execute_changeRunner($config, $metadata, $comment): void
+{
+    preg_match(
+        "/@" . $config->botName . "\schange\srunner\s([^\s]+)(?:\s+((?:(?!\s+@" . $config->botName . ").)*))?/",
+        $comment->CommentBody,
+        $matches
+    );
+
+    if (count($matches) < 2) {
+        doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "-1"), "POST");
+        doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $metadata["errorMessages"]["invalidParameter"]), "POST");
+        return;
+    }
+
+    doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
+    $parameters = array("runner" => $matches[1]);
+    $jobs = isset($matches[2]) ? trim($matches[2]) : "";
+    if ($jobs !== "" && $jobs !== "all") {
+        $parameters["jobs"] = $jobs;
+    }
+
+    $body = "Changing the GitHub Actions runner to `{$matches[1]}`! :runner:";
+    doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+    callWorkflow($config, $metadata, $comment, "change-runner.yml", $parameters);
+}
+
 function execute_codacyBypass($config, $metadata, $comment): void
 {
     global $codacyApiToken, $logger;


### PR DESCRIPTION
Adds the missing handler for the existing `change runner` command so comments like `@gstraccini change runner ubuntu-latest build-job` dispatch the `change-runner.yml` workflow with the selected runner and optional jobs. The handler follows the existing command pattern by reacting to the comment, validating parameters, posting a short status message, and passing the parsed inputs into the workflow dispatch.

## Summary by Sourcery

New Features:
- Support changing the GitHub Actions runner via a bot command that triggers the change-runner workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new comment command allowing users to change a runner. The system validates command parameters, provides visual feedback through emoji reactions, posts a confirmation message, and automatically triggers the workflow to apply the runner change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/gstraccini-bot-service/pull/1063)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->