### PR TITLE
feat: add command for .NET centralized package management +semver: minor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,6 @@
         "startswith",
         "VERIFYHOST",
         "VERIFYPEER"
-    ]
+    ],
+    "snyk.advanced.autoSelectOrganization": true
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ GStraccini-bot can handle various tasks. Here’s a list of commands:
 - `@gstraccini copy issue`: Copies an issue from one repository to another.
 - `@gstraccini copy labels`: Copies the labels from another repository.
 - `@gstraccini create labels`: Creates the default labels in the repository.
-- `@gstraccini dotnet centralised package converter`: Converts projects to use centralized package management using [central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter) (only for **.NET** projects).
+- `@gstraccini dotnet centralised package converter`: Converts projects to use centralised package management using [central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter) (only for **.NET** projects).
 - `@gstraccini dotnet slnx`: Migrates `.sln` files to `.slnx` files using `dotnet sln migrate` (only for **.NET** projects).
 - `@gstraccini csharpier`: Formats the C# code using [CSharpier](https://csharpier.com) (only for **.NET** projects).
 - `@gstraccini fix csproj`: Updates the `.csproj` file with the `packages.config` version of [NuGet packages](https://nuget.org) (only for **.NET Framework** projects).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ GStraccini-bot can handle various tasks. Here’s a list of commands:
 - `@gstraccini copy issue`: Copies an issue from one repository to another.
 - `@gstraccini copy labels`: Copies the labels from another repository.
 - `@gstraccini create labels`: Creates the default labels in the repository.
+- `@gstraccini dotnet centralised package converter`: Converts projects to use centralized package management using [central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter) (only for **.NET** projects).
 - `@gstraccini dotnet slnx`: Migrates `.sln` files to `.slnx` files using `dotnet sln migrate` (only for **.NET** projects).
 - `@gstraccini csharpier`: Formats the C# code using [CSharpier](https://csharpier.com) (only for **.NET** projects).
 - `@gstraccini fix csproj`: Updates the `.csproj` file with the `packages.config` version of [NuGet packages](https://nuget.org) (only for **.NET Framework** projects).

--- a/Src/comments.php
+++ b/Src/comments.php
@@ -686,6 +686,25 @@ function execute_csharpier($config, $metadata, $comment): void
 }
 
 /**
+ * Executes the dotnet centralised package converter command.
+ *
+ * @param object $config   Configuration object containing bot settings.
+ * @param array  $metadata Metadata array with token, URLs, and other context.
+ * @param object $comment  The comment object that triggered this command.
+ *
+ * @return void
+ */
+function execute_dotnetCentralisedPackageConverter($config, $metadata, $comment): void
+{
+    doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
+    $body = "Converting projects to use centralized package management using " .
+        "[central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter)! :wrench:";
+    doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+    callWorkflow($config, $metadata, $comment, "dotnet-centralised-package-converter.yml");
+}
+
+
+/**
  * Executes the dotnet slnx command to migrate .sln files to .slnx files.
  *
  * @param object $config   Configuration object containing bot settings.

--- a/Src/config/commands.json
+++ b/Src/config/commands.json
@@ -156,6 +156,11 @@
         "requiresPullRequestOpen": true
     },
     {
+        "command": "dotnet centralised package converter",
+        "description": "Converts projects to use centralized package management using [central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter) (only for **.NET** projects).",
+        "requiresPullRequestOpen": true
+    },
+    {
         "command": "dotnet slnx",
         "description": "Migrates `.sln` files to `.slnx` files using `dotnet sln migrate` (only for **.NET** projects).",
         "requiresPullRequestOpen": true


### PR DESCRIPTION
## 📑 Description
Introduce a new command `dotnet centralised package converter` to enable centralized package management using the CentralisedPackageConverter tool. This change involves updates to `.vscode/settings.json`, `README.md`, `Src/comments.php`, and `Src/config/commands.json`. This addition enhances the automation capabilities of the bot for .NET projects, providing a streamlined process for managing package dependencies efficiently.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Introduce a new bot command and associated workflow to convert .NET projects to use centralized package management via the CentralisedPackageConverter tool.

New Features:
- Add a dotnet centralized package converter command to trigger a workflow that converts projects to centralized package management for .NET repositories.

Enhancements:
- Register the new centralized package converter command in the commands configuration and editor settings for easier invocation.

Documentation:
- Document the new dotnet centralized package converter bot command and its purpose in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `.gstraccini dotnet centralised package converter` command for converting .NET projects to centralized package management.

* **Documentation**
  * Updated available commands list to include the new centralized package converter command with its description and .NET-specific constraint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/gstraccini-bot-service/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->