### PR TITLE
feat: add autofix parameter to dotnet package converter

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -696,11 +696,22 @@ function execute_csharpier($config, $metadata, $comment): void
  */
 function execute_dotnetCentralisedPackageConverter($config, $metadata, $comment): void
 {
+    preg_match(
+        "/@" . $config->botName . "\sdotnet\scentralised\spackage\sconverter(?:\sautofix\s(true|false))?/i",
+        $comment->CommentBody,
+        $matches
+    );
+    $parameters = array();
+
+    if (count($matches) === 2) {
+        $parameters["autofix"] = $matches[1];
+    }
+
     doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
     $body = "Converting projects to use centralized package management using " .
         "[central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter)! :wrench:";
     doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
-    callWorkflow($config, $metadata, $comment, "dotnet-centralised-package-converter.yml");
+    callWorkflow($config, $metadata, $comment, "dotnet-centralised-package-converter.yml", $parameters);
 }
 
 

--- a/Src/config/commands.json
+++ b/Src/config/commands.json
@@ -158,6 +158,13 @@
     {
         "command": "dotnet centralised package converter",
         "description": "Converts projects to use centralized package management using [central-pkg-converter](https://github.com/Webreaper/CentralisedPackageConverter) (only for **.NET** projects).",
+        "parameters": [
+            {
+                "parameter": "autofix",
+                "description": "Whether to automatically fix and apply the changes (`true` or `false`). Defaults to `false`.",
+                "required": false
+            }
+        ],
         "requiresPullRequestOpen": true
     },
     {


### PR DESCRIPTION
## 📑 Description
Introduce an optional 'autofix' parameter to the 'dotnet centralised package converter' command, allowing automatic application of fixes based on the user's preference. This enhancement offers additional flexibility in managing package conversions and aligns the command with recent project requirements. Updated documentation in commands.json to reflect the change.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add optional autofix support to the dotnet centralised package converter command and propagate it to the corresponding workflow trigger.

New Features:
- Allow the dotnet centralised package converter chat command to accept an optional autofix true/false argument.
- Pass parsed command parameters into the dotnet-centralised-package-converter GitHub workflow invocation.