### PR TITLE
feat: add OpenAPI documentation for API v1 +semver: minor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,12 +180,16 @@ jobs:
   deploy-api:
     name: 🚀 Deploy API to FTP
     runs-on: ubuntu-latest
+    needs: [deploy-service]
 
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 
+          fetch-depth: 0
+
+      - name: 📝 Create Version File
+        run: echo "${{ needs.deploy-service.outputs.fullSemVer }}" > Src/api/v1/version.txt
 
       - name: 📋 Copy commands.json to API
         run: cp Src/config/commands.json Src/api/v1/

--- a/Src/api/v1/.htaccess
+++ b/Src/api/v1/.htaccess
@@ -2,8 +2,11 @@ Options -Indexes
 
 RewriteEngine On
 
+RewriteRule ^openapi\.yaml$ openapi.php [NC,L]
+
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f
 
 RewriteRule ^commands$ commands.php [NC,L]
 RewriteRule ^health$ health.php [NC,L]
+RewriteRule ^swagger$ swagger.php [NC,L]

--- a/Src/api/v1/openapi.php
+++ b/Src/api/v1/openapi.php
@@ -1,0 +1,10 @@
+<?php
+
+header('Content-Type: application/yaml');
+header('Access-Control-Allow-Origin: *');
+
+$versionFile = __DIR__ . '/version.txt';
+$version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : '1.0.0';
+
+$yaml = file_get_contents(__DIR__ . '/openapi.yaml');
+echo str_replace('__APP_VERSION__', $version, $yaml);

--- a/Src/api/v1/openapi.yaml
+++ b/Src/api/v1/openapi.yaml
@@ -1,0 +1,122 @@
+openapi: 3.0.3
+info:
+  title: gstraccini Bot API
+  description: API for the gstraccini GitHub bot service
+  version: __APP_VERSION__
+  contact:
+    name: Guilherme Branco Stracini
+    email: guilherme@guilhermebranco.com.br
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: /api/v1
+    description: API v1
+tags:
+  - name: Health
+    description: Service health endpoints
+  - name: Commands
+    description: Bot commands documentation
+paths:
+  /health:
+    get:
+      summary: Health check
+      description: Returns the health status of the service
+      operationId: getHealth
+      tags:
+        - Health
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Healthy
+  /commands:
+    get:
+      summary: Get bot commands
+      description: Returns the list of available bot commands in the specified format
+      operationId: getCommands
+      tags:
+        - Commands
+      parameters:
+        - name: format
+          in: query
+          description: Output format for the commands documentation
+          required: false
+          schema:
+            type: string
+            enum:
+              - markdown
+              - simplemd
+              - html
+              - text
+              - json
+            default: markdown
+      responses:
+        '200':
+          description: Commands documentation in the requested format
+          content:
+            text/markdown:
+              schema:
+                type: string
+                example: "## Available Commands\n\n### help\n- **Description**: Shows help"
+            text/html:
+              schema:
+                type: string
+            text/plain:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Command'
+components:
+  schemas:
+    Command:
+      type: object
+      required:
+        - command
+        - description
+      properties:
+        command:
+          type: string
+          description: The command name
+          example: help
+        description:
+          type: string
+          description: Description of what the command does
+          example: Shows help information
+        parameters:
+          type: array
+          description: List of parameters accepted by the command
+          items:
+            $ref: '#/components/schemas/CommandParameter'
+        requiresPullRequestOpen:
+          type: boolean
+          description: Whether the command requires an open pull request
+          default: false
+        dev:
+          type: boolean
+          description: Whether this is a developer-only command
+          default: false
+    CommandParameter:
+      type: object
+      required:
+        - parameter
+        - description
+      properties:
+        parameter:
+          type: string
+          description: The parameter name
+          example: repository
+        description:
+          type: string
+          description: Description of the parameter
+          example: The repository name
+        required:
+          type: boolean
+          description: Whether the parameter is required
+          default: false

--- a/Src/api/v1/swagger.php
+++ b/Src/api/v1/swagger.php
@@ -1,0 +1,39 @@
+<?php
+
+header('Content-Type: text/html; charset=UTF-8');
+
+$versionFile = __DIR__ . '/version.txt';
+$version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : '1.0.0';
+$pageTitle = 'gstraccini Bot API v' . htmlspecialchars($version) . ' - Swagger UI';
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><?= $pageTitle ?></title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css" integrity="sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT" crossorigin="anonymous">
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js" integrity="sha384-EYdOaiRwn44zNjrw+Tfs06qYz9BGQVo2f4/pLY5i7VorbjnZNhdplAbTBk8FXHUJ" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js" integrity="sha384-49fpFaVrAWI/qdgl9Vv5E/4NXxRUiJX5vGuLws1NUpTWGtEqzWEx8gHTw2UTehFK" crossorigin="anonymous"></script>
+<script>
+  window.onload = function () {
+    SwaggerUIBundle({
+      url: '/api/v1/openapi.yaml',
+      dom_id: '#swagger-ui',
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      layout: 'StandaloneLayout',
+      deepLinking: true,
+      displayRequestDuration: true,
+      filter: true
+    });
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📑 Description
Add an OpenAPI 3.0 specification (openapi.yaml) for the API v1, detailing the health and commands endpoints. Introduce new php scripts (openapi.php and swagger.php) to serve the OpenAPI definition and render Swagger UI. Modify the .htaccess to route requests for openapi.yaml and swagger appropriately.

The addition of OpenAPI documentation enhances the developer experience by providing clear, standardized API documentation and interactive Swagger UI for testing the API. This is crucial for maintaining API consistency and improving usability for integrators and developers.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add versioned OpenAPI documentation and Swagger UI for API v1 and wire it into the deployment workflow.

New Features:
- Introduce an OpenAPI 3.0 specification for API v1 health and commands endpoints.
- Expose the OpenAPI definition via a dedicated PHP endpoint and provide a Swagger UI page for interactive API exploration.

Enhancements:
- Generate and deploy an API version file from the service deployment workflow to keep the documentation version in sync with the deployed service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive REST API documentation using OpenAPI 3.0.3 specification.
  * Deployed interactive Swagger UI for exploring and testing API endpoints.
  * Configured versioned API documentation that automatically syncs with service deployments.
  * Documented health status and commands endpoints with parameter options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/gstraccini-bot-service/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->