### PR TITLE
fix: add optional trailing slash in rewrite rules

### DIFF
--- a/Src/api/v1/.htaccess
+++ b/Src/api/v1/.htaccess
@@ -7,7 +7,7 @@ RewriteRule ^openapi\.yaml$ openapi.php [NC,L]
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f
 
-RewriteRule ^commands$ commands.php [NC,L]
-RewriteRule ^health$ health.php [NC,L]
-RewriteRule ^swagger$ swagger.php [NC,L]
-RewriteRule ^jobs/([a-zA-Z]+)$ jobs.php [NC,L]
+RewriteRule ^commands/?$ commands.php [NC,L]
+RewriteRule ^health/?$ health.php [NC,L]
+RewriteRule ^swagger/?$ swagger.php [NC,L]
+RewriteRule ^jobs/([a-zA-Z]+)/?$ jobs.php [NC,L]


### PR DESCRIPTION
## 📑 Description
Ensure that URL endpoints defined in the .htaccess file accept optional trailing slashes. Modify rewrite rules for "commands", "health", "swagger", and "jobs" to improve flexibility and enhance user experience. This change prevents URL mismatches when accessing endpoints with trailing slashes, maintaining a consistent behavior across all endpoints.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Allow API v1 endpoints in the .htaccess configuration to accept optional trailing slashes for key routes.

Enhancements:
- Relax URL rewrite rules for commands, health, swagger, and jobs endpoints to support optional trailing slashes and improve routing flexibility.

Documentation:
- Update documentation to reflect that key API v1 endpoints now accept URLs with or without trailing slashes.