### PR TITLE
Add installations.php for handling installations

### DIFF
--- a/Src/Workers/installations.php
+++ b/Src/Workers/installations.php
@@ -1,0 +1,16 @@
+<?php
+
+chdir(__DIR__ . '/../');
+require_once "config/config.php";
+
+use GuiBranco\GStracciniBot\Library\LabelHelper;
+use GuiBranco\GStracciniBot\Library\ProcessingManager;
+use GuiBranco\Pancake\GUIDv4;
+use GuiBranco\Pancake\HealthChecks;
+use GuiBranco\Pancake\LogStream;
+
+function handleItem($installation) {}
+
+$healthCheck = new HealthChecks($healthChecksIoInstallations, GUIDv4::random());
+$processor = new ProcessingManager("installations", $healthCheck, $logger, $logStream);
+$processor->run("handleItem", 60);

--- a/Src/Workers/installations.php
+++ b/Src/Workers/installations.php
@@ -9,7 +9,22 @@ use GuiBranco\Pancake\GUIDv4;
 use GuiBranco\Pancake\HealthChecks;
 use GuiBranco\Pancake\LogStream;
 
-function handleItem($installation) {}
+/**
+ * Handle a single installation item from the ProcessingManager.
+ *
+ * @param array<string,mixed> $installation
+ */
+function handleItem(array $installation): void
+{
+    // Minimal implementation to avoid silently "processing" items with no effect.
+    // This can be expanded to perform real processing as needed.
+    $installationId = $installation['id'] ?? $installation['installation_id'] ?? 'unknown';
+
+    error_log(sprintf(
+        '[installations] Received installation payload (id: %s)'
+        , (string) $installationId
+    ));
+}
 
 $healthCheck = new HealthChecks($healthChecksIoInstallations, GUIDv4::random());
 $processor = new ProcessingManager("installations", $healthCheck, $logger, $logStream);


### PR DESCRIPTION
## 📑 Description
Add installations.php for handling installations

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a new worker entry point for processing installation items using the existing processing infrastructure.

New Features:
- Introduce an installations worker script wired into the ProcessingManager pipeline for handling installation-related items.

Enhancements:
- Integrate health checks and logging into the new installations worker using existing monitoring and logging components.