### PR TITLE
feat: add pin action command for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ GStraccini-bot can handle various tasks. Here’s a list of commands:
   **.NET** projects).
 - `@gstraccini npm dist`: Generates or regenerates the `dist` files by running `npm run package` (only for **NPM** projects).
 - `@gstraccini npm lint fix`: Fixes linting issues by running `npm run lint -- --fix` (only for **NPM** projects).
+- `@gstraccini pin action`: Pins GitHub Actions references to their commit SHA using [pin-github-action](https://www.npmjs.com/package/pin-github-action). Accepts an optional workflow path or glob pattern (defaults to `.github/workflows/*.yml`).
 - `@gstraccini prettier`: Formats the code using [Prettier](https://prettier.io).
 - `@gstraccini rerun checks`: Reruns the checks in the target pull request with a matching conclusion.
 - `@gstraccini rerun workflows`: Reruns the workflows (actions) in the target pull request. Only applicable for GitHub Actions.

--- a/Src/Workers/comments.php
+++ b/Src/Workers/comments.php
@@ -759,6 +759,26 @@ function execute_phpcs($config, $metadata, $comment): void
     callWorkflow($config, $metadata, $comment, "phpcs-autofix.yml", $parameters);
 }
 
+function execute_pinAction($config, $metadata, $comment): void
+{
+    preg_match(
+        "/@" . $config->botName . "\spin\saction(?:\s(\S+))?/",
+        $comment->CommentBody,
+        $matches
+    );
+    $parameters = array();
+
+    if (count($matches) === 2) {
+        $parameters["workflow"] = $matches[1];
+    }
+
+    doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
+    $body = "Pinning GitHub Actions to their commit SHA using [pin-github-action]" .
+        "(https://www.npmjs.com/package/pin-github-action)! :pushpin:";
+    doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+    callWorkflow($config, $metadata, $comment, "pin-github-action.yml", $parameters);
+}
+
 function execute_prettier($config, $metadata, $comment): void
 {
     doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");

--- a/Src/comments.php
+++ b/Src/comments.php
@@ -846,6 +846,26 @@ function execute_phpcs($config, $metadata, $comment): void
     callWorkflow($config, $metadata, $comment, "phpcs-autofix.yml", $parameters);
 }
 
+function execute_pinAction($config, $metadata, $comment): void
+{
+    preg_match(
+        "/@" . $config->botName . "\spin\saction(?:\s(\S+))?/",
+        $comment->CommentBody,
+        $matches
+    );
+    $parameters = array();
+
+    if (count($matches) === 2) {
+        $parameters["workflow"] = $matches[1];
+    }
+
+    doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
+    $body = "Pinning GitHub Actions to their commit SHA using [pin-github-action]" .
+        "(https://www.npmjs.com/package/pin-github-action)! :pushpin:";
+    doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+    callWorkflow($config, $metadata, $comment, "pin-github-action.yml", $parameters);
+}
+
 function execute_prettier($config, $metadata, $comment): void
 {
     doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");

--- a/Src/config/commands.json
+++ b/Src/config/commands.json
@@ -229,6 +229,18 @@
         "requiresPullRequestOpen": true
     },
     {
+        "command": "pin action",
+        "description": "Pins GitHub Actions references to their commit SHA using [pin-github-action](https://www.npmjs.com/package/pin-github-action).",
+        "parameters": [
+            {
+                "parameter": "workflow",
+                "description": "The workflow file path or glob pattern to pin. Defaults to `.github/workflows/*.yml` when omitted.",
+                "required": false
+            }
+        ],
+        "requiresPullRequestOpen": true
+    },
+    {
         "command": "prettier",
         "description": "Formats the code using [Prettier](https://prettier.io).",
         "requiresPullRequestOpen": true


### PR DESCRIPTION
## 📑 Description
Introduce the `@gstraccini pin action` command, enabling the bot to pin GitHub Actions references to their specific commit SHA using the `pin-github-action` tool. This command accepts an optional workflow path or glob pattern, defaulting to `.github/workflows/*.yml`. The addition enhances the bot's capabilities by improving the security and stability of CI/CD workflows by explicitly defining the exact versions of the GitHub Actions to be used, thus reducing unexpected behavior due to sudden upstream changes.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a new bot command to pin GitHub Actions references to specific commit SHAs and document its usage.

New Features:
- Introduce the `@<botName> pin action` command to trigger a workflow that pins GitHub Actions to their commit SHAs, optionally scoped to a given workflow path or glob pattern.

Documentation:
- Document the new `@gstraccini pin action` command and its behavior in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bot command to pin GitHub Actions references to specific commit SHAs.
  * The command can optionally target a specific workflow path or use the default workflow pattern.

* **Documentation**
  * Updated the command list in the README with usage details and the new pinning command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->