### PR TITLE
feat: add automerge tracking to GitHub pull request handling +semver:minor

### DIFF
--- a/Sql/0006.alter_github_pull_requests_add_automerge_tracking.sql
+++ b/Sql/0006.alter_github_pull_requests_add_automerge_tracking.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `github_pull_requests`
+    ADD COLUMN `AutoMergeEnabled` BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN `AutoMergeEnabledAt` TIMESTAMP NULL,
+    ADD COLUMN `Merged` BOOLEAN NOT NULL DEFAULT FALSE;

--- a/Src/Workers/pullRequests.php
+++ b/Src/Workers/pullRequests.php
@@ -67,7 +67,7 @@ function handleItem($pullRequest, $isRetry = false)
             $pullRequest->DeliveryIdText
         );
         if ($pullRequest->State !== "CLOSED") {
-            updateStateToClosedInTable("pull_requests", $pullRequest->Sequence);
+            updatePullRequestClosedState($pullRequest->Sequence, $pullRequestUpdated->merged ?? false);
         }
 
         return;
@@ -664,7 +664,10 @@ function enableAutoMerge($metadata, $pullRequest, $pullRequestUpdated, $config)
                  }
         }"
         );
-        doRequestGitHub($metadata["userToken"], "graphql", $body, "POST");
+        $autoMergeResponse = doRequestGitHub($metadata["userToken"], "graphql", $body, "POST");
+        if ($autoMergeResponse->getStatusCode() < 300) {
+            markPullRequestAutoMergeEnabled($pullRequest->Sequence);
+        }
 
         $label = array("labels" => array("☑️ auto-merge"));
         doRequestGitHub($metadata["token"], $metadata["labelsUrl"], $label, "POST");

--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -104,6 +104,43 @@ function updateStateToClosedInTable($table, $sequence): bool
     return $succeeded;
 }
 
+function markPullRequestAutoMergeEnabled($sequence): bool
+{
+    $mysqli = connectToDatabase();
+
+    $sql = "UPDATE github_pull_requests SET AutoMergeEnabled = TRUE, AutoMergeEnabledAt = NOW() WHERE Sequence = ? AND AutoMergeEnabled = FALSE";
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param("i", $sequence);
+    $succeeded = false;
+
+    if ($stmt->execute()) {
+        $succeeded = $stmt->affected_rows === 1;
+    }
+
+    $stmt->close();
+    $mysqli->close();
+    return $succeeded;
+}
+
+function updatePullRequestClosedState($sequence, $merged): bool
+{
+    $mysqli = connectToDatabase();
+
+    $sql = "UPDATE github_pull_requests SET State = 'CLOSED', Merged = ? WHERE Sequence = ? AND State = 'OPEN'";
+    $stmt = $mysqli->prepare($sql);
+    $mergedInt = $merged ? 1 : 0;
+    $stmt->bind_param("ii", $mergedInt, $sequence);
+    $succeeded = false;
+
+    if ($stmt->execute()) {
+        $succeeded = $stmt->affected_rows === 1;
+    }
+
+    $stmt->close();
+    $mysqli->close();
+    return $succeeded;
+}
+
 function upsertPullRequest($pullRequest)
 {
     $mysqli = connectToDatabase();

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -34,7 +34,7 @@ function handleItem($pullRequest, $isRetry = false)
     if ($pullRequestUpdated->state != "open") {
         echo "PR State: {$pullRequestUpdated->state} ⛔\n";
         if ($pullRequest->State !== "CLOSED") {
-            updateStateToClosedInTable("pull_requests", $pullRequest->Sequence);
+            updatePullRequestClosedState($pullRequest->Sequence, $pullRequestUpdated->merged ?? false);
         }
 
         return;
@@ -700,7 +700,10 @@ function enableAutoMerge($metadata, $pullRequest, $pullRequestUpdated, $config)
                  }
         }"
         );
-        doRequestGitHub($metadata["userToken"], "graphql", $body, "POST");
+        $autoMergeResponse = doRequestGitHub($metadata["userToken"], "graphql", $body, "POST");
+        if ($autoMergeResponse->getStatusCode() < 300) {
+            markPullRequestAutoMergeEnabled($pullRequest->Sequence);
+        }
 
         $label = array("labels" => array("☑️ auto-merge"));
         doRequestGitHub($metadata["token"], $metadata["labelsUrl"], $label, "POST");


### PR DESCRIPTION
## 📑 Description
Introduce automerge tracking to the system by altering the `github_pull_requests` table. Add columns `AutoMergeEnabled`, `AutoMergeEnabledAt`, and `Merged` to track automerge-related information.

Refactor the `pullRequests.php` and associated database functions to support these new changes. Replace the `updateStateToClosedInTable` with `updatePullRequestClosedState` to record whether a pull request is merged. Add `markPullRequestAutoMergeEnabled` function to update when automerge is enabled successfully.

These changes improve traceability of pull request states and automerge actions, assisting in tracking and auditing pull request handling.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Track GitHub pull request automerge status and merged state in the database and worker flows.

New Features:
- Record when automerge is enabled for a GitHub pull request, including the timestamp of activation.
- Persist whether a GitHub pull request was merged when it is closed.

Enhancements:
- Update pull request worker handling to store merged state on close and mark automerge as enabled only after successful GitHub API calls.