### PR TITLE
feat: detect GitHub Actions version bumps

### DIFF
--- a/Src/Library/DependencyFileLabelService.php
+++ b/Src/Library/DependencyFileLabelService.php
@@ -100,6 +100,20 @@ class DependencyFileLabelService
     ];
 
     /**
+     * Pattern matching GitHub Actions workflow and composite action files
+     *
+     * @var string
+     */
+    private $gitHubActionsFilePattern = '/^(\.github\/(workflows|actions)\/.+\.ya?ml|action\.ya?ml)$/i';
+
+    /**
+     * Pattern matching a `uses: owner/repo[/path]@ref` line within a workflow diff
+     *
+     * @var string
+     */
+    private $actionUsesPattern = '/uses:\s*[\'"]?([\w.\-]+(?:\/[\w.\-]+)+)@([\w.\-]+)/';
+
+    /**
      * Analyzes a pull request diff to detect dependency file changes
      *
      * @param string $diffContent The pull request diff content
@@ -110,6 +124,8 @@ class DependencyFileLabelService
         $lines = explode("\n", str_replace("\r\n", "\n", $diffContent));
         $detectedFiles = [];
         $currentFile = null;
+        $removedActionUses = [];
+        $addedActionUses = [];
 
         foreach ($lines as $line) {
             $line = rtrim($line, "\r");
@@ -118,10 +134,20 @@ class DependencyFileLabelService
             }
 
             if (preg_match('/^\+\+\+ b\/(.+)/', $line, $matches)) {
+                $this->checkActionVersionBump($currentFile, $removedActionUses, $addedActionUses, $detectedFiles);
                 $currentFile = $matches[1];
+                $removedActionUses = [];
+                $addedActionUses = [];
                 $this->checkDependencyFile($currentFile, $detectedFiles);
+                continue;
+            }
+
+            if ($currentFile !== null && preg_match($this->gitHubActionsFilePattern, $currentFile)) {
+                $this->collectActionUse($line, $removedActionUses, $addedActionUses);
             }
         }
+
+        $this->checkActionVersionBump($currentFile, $removedActionUses, $addedActionUses, $detectedFiles);
 
         return $detectedFiles;
     }
@@ -139,6 +165,54 @@ class DependencyFileLabelService
             if (preg_match('/' . $pattern . '/i', $filePath)) {
                 $detectedFiles[$info['label']] = $info['package_manager'];
                 break;
+            }
+        }
+    }
+
+    /**
+     * Collects `uses: owner/repo@ref` references from a removed or added diff line
+     *
+     * @param string $line The raw diff line, including its leading +/- marker
+     * @param array &$removedActionUses Map of action name => ref found on removed lines
+     * @param array &$addedActionUses Map of action name => ref found on added lines
+     * @return void
+     */
+    private function collectActionUse(string $line, array &$removedActionUses, array &$addedActionUses): void
+    {
+        if (preg_match('/^-(?!--)/', $line) && preg_match($this->actionUsesPattern, $line, $matches)) {
+            $removedActionUses[$matches[1]] = $matches[2];
+            return;
+        }
+
+        if (preg_match('/^\+(?!\+\+)/', $line) && preg_match($this->actionUsesPattern, $line, $matches)) {
+            $addedActionUses[$matches[1]] = $matches[2];
+        }
+    }
+
+    /**
+     * Determines whether a workflow file's diff contains a GitHub Actions version bump
+     * (i.e. the same action reference with a different version) and, if so, labels it
+     *
+     * @param string|null $filePath The file being analyzed
+     * @param array $removedActionUses Map of action name => ref found on removed lines
+     * @param array $addedActionUses Map of action name => ref found on added lines
+     * @param array &$detectedFiles Reference to the array of detected files
+     * @return void
+     */
+    private function checkActionVersionBump(
+        ?string $filePath,
+        array $removedActionUses,
+        array $addedActionUses,
+        array &$detectedFiles
+    ): void {
+        if ($filePath === null) {
+            return;
+        }
+
+        foreach ($addedActionUses as $action => $newVersion) {
+            if (isset($removedActionUses[$action]) && $removedActionUses[$action] !== $newVersion) {
+                $detectedFiles['github-actions'] = 'GitHub Actions';
+                return;
             }
         }
     }

--- a/Src/Tests/Library/DependencyFileLabelServiceTest.php
+++ b/Src/Tests/Library/DependencyFileLabelServiceTest.php
@@ -82,4 +82,77 @@ class DependencyFileLabelServiceTest extends TestCase
 
         $this->assertSame([], $result);
     }
+
+    private function buildWorkflowDiff(string $filePath, array $removedLines, array $addedLines): string
+    {
+        $lines = [
+            "diff --git a/{$filePath} b/{$filePath}",
+            "index 111..222 100644",
+            "--- a/{$filePath}",
+            "+++ b/{$filePath}",
+            "@@ -1," . count($removedLines) . " +1," . count($addedLines) . " @@",
+        ];
+
+        foreach ($removedLines as $removedLine) {
+            $lines[] = "-{$removedLine}";
+        }
+
+        foreach ($addedLines as $addedLine) {
+            $lines[] = "+{$addedLine}";
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    public function testDetectsGitHubActionsVersionBumpInWorkflow(): void
+    {
+        $diff = $this->buildWorkflowDiff(
+            ".github/workflows/ci.yml",
+            ["      - uses: actions/checkout@v3"],
+            ["      - uses: actions/checkout@v4"]
+        );
+
+        $result = $this->service->detectDependencyChanges($diff);
+
+        $this->assertSame(["github-actions" => "GitHub Actions"], $result);
+    }
+
+    public function testDetectsGitHubActionsVersionBumpInCompositeAction(): void
+    {
+        $diff = $this->buildWorkflowDiff(
+            ".github/actions/setup/action.yml",
+            ["  - uses: actions/setup-node@v3.8.0"],
+            ["  - uses: actions/setup-node@v4.0.0"]
+        );
+
+        $result = $this->service->detectDependencyChanges($diff);
+
+        $this->assertSame(["github-actions" => "GitHub Actions"], $result);
+    }
+
+    public function testIgnoresWorkflowChangesThatAreNotVersionBumps(): void
+    {
+        $diff = $this->buildWorkflowDiff(
+            ".github/workflows/ci.yml",
+            ["      run: echo old"],
+            ["      run: echo new"]
+        );
+
+        $result = $this->service->detectDependencyChanges($diff);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testIgnoresUnchangedActionReferences(): void
+    {
+        $diff = $this->buildWorkflowDiff(
+            ".github/workflows/ci.yml",
+            ["      - uses: actions/checkout@v4", "      run: echo old"],
+            ["      - uses: actions/checkout@v4", "      run: echo new"]
+        );
+
+        $result = $this->service->detectDependencyChanges($diff);
+
+        $this->assertSame([], $result);
+    }
 }


### PR DESCRIPTION
## 📑 Description
Enhance `DependencyFileLabelService` to detect version changes in GitHub Actions workflows and composite actions. Introduce patterns to match workflow files and `uses:` lines in diffs. Add logic to track added and removed action versions, labeling them under "github-actions" if a version change occurs. This enables automatic detection of GitHub Actions version updates, improving dependency management tracking.

Include unit tests to validate the detection of version bumps and ignore non-version changes or unchanged action references.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PRs that update GitHub Actions workflow or composite action versions can now be labeled accordingly.
  * Changes to action references in workflow files are detected more reliably, even with varied spacing or quoting.

* **Bug Fixes**
  * Non-version edits inside workflow files are no longer mistaken for dependency updates.
  * Mixed changes in a workflow now only trigger a label when the action version actually changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->