### PR TITLE
feat: implement handling of infisicalignore suggestions +semver: minor

### DIFF
--- a/Src/Handlers/CommentsHandler.php
+++ b/Src/Handlers/CommentsHandler.php
@@ -4,9 +4,13 @@ namespace GuiBranco\GStracciniBot\Handlers;
 
 use GuiBranco\GStracciniBot\Library\Codacy;
 use GuiBranco\GStracciniBot\Library\CommandHelper;
+use GuiBranco\GStracciniBot\Library\InfisicalIgnoreApprovalCommentBuilder;
+use GuiBranco\GStracciniBot\Library\InfisicalIgnoreCommitService;
+use GuiBranco\GStracciniBot\Library\InfisicalIgnoreSuggestionParser;
 use GuiBranco\GStracciniBot\Library\LabelHelper;
 use GuiBranco\GStracciniBot\Library\LabelService;
 use GuiBranco\GStracciniBot\Library\RepositoryManager;
+use RuntimeException;
 
 /**
  * Handles issue-comment events shared by the HTTP webhook entry point
@@ -72,12 +76,25 @@ class CommentsHandler implements IHandler
             $comment->DeliveryIdText
         );
     
+        $action = $comment->Action ?? "created";
+        if ($action === "edited" && $sender === $config->botName . "[bot]") {
+            $metadata = $this->buildMetadata($comment, $config);
+            $this->execute_applyInfisicalIgnoreSuggestion($config, $metadata, $comment);
+            return;
+        }
+
         if ($sender === $config->botName . "[bot]") {
             return;
         }
-    
+
         $ignoredBots = ["github-actions[bot]", "AppVeyorBot", "gitauto-ai[bot]"];
         if (in_array($sender, $ignoredBots, true)) {
+            if ($sender === "github-actions[bot]") {
+                $metadata = $this->buildMetadata($comment, $config);
+                if ($this->execute_detectInfisicalIgnoreSuggestion($config, $metadata, $comment)) {
+                    return;
+                }
+            }
             echo "Skipping this comment! 🚷\n";
             $logStream?->info(
                 "Skipping comment from ignored bot: {$sender}",
@@ -88,7 +105,7 @@ class CommentsHandler implements IHandler
             $this->reactToComment($comment, "-1");
             return;
         }
-    
+
         $metadata = $this->buildMetadata($comment, $config);
     
         if (!$this->isCollaborator($comment, $metadata)) {
@@ -1072,6 +1089,125 @@ class CommentsHandler implements IHandler
         $this->callWorkflow($config, $metadata, $comment, "update-test-snapshot.yml");
     }
     
+    /**
+     * Detects a `.infisicalignore` suggestion posted by github-actions[bot] and, if found,
+     * posts a checkbox approval comment for a maintainer to opt in to applying it.
+     *
+     * @return bool True if this comment was an infisicalignore suggestion (handled), false otherwise.
+     */
+    private function execute_detectInfisicalIgnoreSuggestion($config, $metadata, $comment): bool
+    {
+        $parser = new InfisicalIgnoreSuggestionParser();
+        $entries = $parser->parse($comment->CommentBody);
+        if ($entries === null) {
+            return false;
+        }
+
+        $builder = new InfisicalIgnoreApprovalCommentBuilder();
+        $marker = $builder->marker((int) $comment->CommentId);
+
+        if ($this->findCommentByMarker($metadata, $marker) !== null) {
+            return true;
+        }
+
+        doRequestGitHub($metadata["token"], $metadata["reactionUrl"], array("content" => "eyes"), "POST");
+        $body = $builder->build(
+            $comment->RepositoryOwner,
+            $comment->RepositoryName,
+            (int) $comment->PullRequestNumber,
+            (int) $comment->CommentId
+        );
+        doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+
+        return true;
+    }
+
+    /**
+     * Handles an edit to the bot's own approval comment: applies the referenced
+     * `.infisicalignore` suggestion once the approval checkbox has been checked.
+     */
+    private function execute_applyInfisicalIgnoreSuggestion($config, $metadata, $comment): void
+    {
+        $approvalCommentUrl = "{$metadata['repoPrefix']}/issues/comments/{$comment->CommentId}";
+        $approvalResponse = doRequestGitHub($metadata["token"], $approvalCommentUrl, null, "GET");
+        if ($approvalResponse->getStatusCode() !== 200) {
+            return;
+        }
+        $approvalComment = json_decode($approvalResponse->getBody());
+        $body = $approvalComment->body;
+
+        if (stripos($body, InfisicalIgnoreApprovalCommentBuilder::COMPLETION_MARKER) !== false) {
+            return;
+        }
+
+        $checkboxLabel = preg_quote(InfisicalIgnoreApprovalCommentBuilder::CHECKBOX_LABEL, "/");
+        if (!preg_match("/-\s\[(x|X)\]\s{$checkboxLabel}/", $body)) {
+            return;
+        }
+
+        $markerPrefix = preg_quote(InfisicalIgnoreApprovalCommentBuilder::MARKER_PREFIX, "/");
+        if (!preg_match("/{$markerPrefix}(\d+)/", $body, $matches)) {
+            return;
+        }
+        $originalCommentId = (int) $matches[1];
+
+        $originalCommentUrl = "{$metadata['repoPrefix']}/issues/comments/{$originalCommentId}";
+        $originalResponse = doRequestGitHub($metadata["token"], $originalCommentUrl, null, "GET");
+        if ($originalResponse->getStatusCode() !== 200) {
+            return;
+        }
+        $originalComment = json_decode($originalResponse->getBody());
+
+        $parser = new InfisicalIgnoreSuggestionParser();
+        $entries = $parser->parse($originalComment->body);
+        if ($entries === null) {
+            return;
+        }
+
+        $pullRequestResponse = doRequestGitHub($metadata["token"], $metadata["pullRequestUrl"], null, "GET");
+        if ($pullRequestResponse->getStatusCode() !== 200) {
+            return;
+        }
+        $pullRequest = json_decode($pullRequestResponse->getBody());
+        $branch = $pullRequest->head->ref;
+
+        $builder = new InfisicalIgnoreApprovalCommentBuilder();
+        $commitService = new InfisicalIgnoreCommitService();
+
+        try {
+            $result = $commitService->applyToPullRequest($metadata, $branch, $entries);
+        } catch (RuntimeException $e) {
+            $failureBody = $body . "\n\n❌ Failed to apply suggestion: " . $e->getMessage() . "\n";
+            doRequestGitHub($metadata["token"], $approvalCommentUrl, array("body" => $failureBody), "PATCH");
+            return;
+        }
+
+        $completion = $builder->buildCompletion($result["sha"] ?? "n/a", $result["message"]);
+        doRequestGitHub($metadata["token"], $approvalCommentUrl, array("body" => $body . $completion), "PATCH");
+    }
+
+    /**
+     * Fetches up to 100 comments on the pull request and returns the first one whose
+     * body contains the given marker, or null if none match.
+     */
+    private function findCommentByMarker(array $metadata, string $marker): ?object
+    {
+        $url = "{$metadata['commentUrl']}?per_page=100&page=1";
+        $response = doRequestGitHub($metadata["token"], $url, null, "GET");
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $comments = json_decode($response->getBody());
+        foreach ($comments as $existingComment) {
+            if (strpos($existingComment->body, $marker) !== false) {
+                return $existingComment;
+            }
+        }
+
+        return null;
+    }
+
     private function callWorkflow($config, $metadata, $comment, $workflow, $extendedParameters = null): void
     {
         global $logger;

--- a/Src/Library/InfisicalIgnoreApprovalCommentBuilder.php
+++ b/Src/Library/InfisicalIgnoreApprovalCommentBuilder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+class InfisicalIgnoreApprovalCommentBuilder
+{
+    public const MARKER_PREFIX = "<!-- gstraccini-bot:infisicalignore:";
+    public const CHECKBOX_LABEL = "Apply this suggestion";
+    public const COMPLETION_MARKER = "<!-- gstraccini-bot:infisicalignore:applied -->";
+
+    public function marker(int $originalCommentId): string
+    {
+        return self::MARKER_PREFIX . $originalCommentId . " -->";
+    }
+
+    public function build(string $owner, string $repo, int $prNumber, int $originalCommentId): string
+    {
+        $permalink = "https://github.com/{$owner}/{$repo}/pull/{$prNumber}#issuecomment-{$originalCommentId}";
+
+        $body = $this->marker($originalCommentId) . "\n";
+        $body .= "### Apply `.infisicalignore` update\n\n";
+        $body .= "> Suggested by @github-actions[bot]\n";
+        $body .= ">\n";
+        $body .= "> {$permalink}\n\n";
+        $body .= "The workflow detected a suggested update for `.infisicalignore`.\n\n";
+        $body .= "- [ ] " . self::CHECKBOX_LABEL . "\n\n";
+        $body .= "Once this checkbox is checked, GStraccini Bot will automatically append the suggested entries " .
+            "to `.infisicalignore` and commit the change to this pull request.\n";
+
+        return $body;
+    }
+
+    public function buildCompletion(string $commitSha, string $commitMessage): string
+    {
+        return "\n\n" . self::COMPLETION_MARKER . "\n" .
+            "✅ Suggestion successfully applied.\n\n" .
+            "Commit: `{$commitSha}` {$commitMessage}\n";
+    }
+}

--- a/Src/Library/InfisicalIgnoreCommitService.php
+++ b/Src/Library/InfisicalIgnoreCommitService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+use RuntimeException;
+
+class InfisicalIgnoreCommitService
+{
+    private const FILE_PATH = ".infisicalignore";
+    private const MAX_ATTEMPTS = 2;
+
+    public function applyToPullRequest(array $metadata, string $branch, array $newLines): array
+    {
+        $fileUpdater = new InfisicalIgnoreFileUpdater();
+        $contentsUrl = "{$metadata['repoPrefix']}/contents/" . self::FILE_PATH;
+
+        $lastError = null;
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            [$existingContent, $sha] = $this->readFile($metadata, $contentsUrl, $branch);
+            $mergedContent = $fileUpdater->merge($existingContent, $newLines);
+
+            if ($existingContent !== null && $mergedContent === $existingContent) {
+                return [
+                    "sha" => null,
+                    "message" => "No new entries to add — `.infisicalignore` already up to date.",
+                ];
+            }
+
+            $body = [
+                "message" => "Add suggested .infisicalignore entries",
+                "content" => base64_encode($mergedContent),
+                "branch" => $branch,
+            ];
+            if ($sha !== null) {
+                $body["sha"] = $sha;
+            }
+
+            $response = doRequestGitHub($metadata["token"], $contentsUrl, $body, "PUT");
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode === 200 || $statusCode === 201) {
+                $result = json_decode($response->getBody(), true);
+                return [
+                    "sha" => $result["commit"]["sha"] ?? null,
+                    "message" => $body["message"],
+                ];
+            }
+
+            if (($statusCode === 409 || $statusCode === 422) && $attempt < self::MAX_ATTEMPTS) {
+                $lastError = $response->getBody();
+                continue;
+            }
+
+            throw new RuntimeException(
+                "Failed to update .infisicalignore: [{$statusCode}] " . $response->getBody()
+            );
+        }
+
+        throw new RuntimeException("Failed to update .infisicalignore after retry: " . $lastError);
+    }
+
+    private function readFile(array $metadata, string $contentsUrl, string $branch): array
+    {
+        $url = $contentsUrl . "?ref=" . urlencode($branch);
+        $response = doRequestGitHub($metadata["token"], $url, null, "GET");
+
+        if ($response->getStatusCode() !== 200) {
+            return [null, null];
+        }
+
+        $fileData = json_decode($response->getBody(), true);
+        if (!isset($fileData["content"]) || ($fileData["encoding"] ?? null) !== "base64") {
+            return [null, null];
+        }
+
+        return [base64_decode($fileData["content"]), $fileData["sha"] ?? null];
+    }
+}

--- a/Src/Library/InfisicalIgnoreFileUpdater.php
+++ b/Src/Library/InfisicalIgnoreFileUpdater.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+class InfisicalIgnoreFileUpdater
+{
+    public function merge(?string $existingContent, array $newLines): string
+    {
+        $existingLines = [];
+        if ($existingContent !== null && trim($existingContent) !== '') {
+            $existingLines = preg_split('/\r?\n/', rtrim($existingContent, "\r\n"));
+        }
+
+        $existingTrimmed = array_map('trim', $existingLines);
+
+        $linesToAppend = [];
+        foreach ($newLines as $newLine) {
+            $newLine = trim($newLine);
+            if ($newLine === '') {
+                continue;
+            }
+            if (in_array($newLine, $existingTrimmed, true) || in_array($newLine, $linesToAppend, true)) {
+                continue;
+            }
+            $linesToAppend[] = $newLine;
+        }
+
+        $mergedLines = array_merge($existingLines, $linesToAppend);
+
+        return implode("\n", $mergedLines) . "\n";
+    }
+}

--- a/Src/Library/InfisicalIgnoreSuggestionParser.php
+++ b/Src/Library/InfisicalIgnoreSuggestionParser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+class InfisicalIgnoreSuggestionParser
+{
+    public function parse(string $commentBody): ?array
+    {
+        $matched = preg_match(
+            '/```suggestion:\.infisicalignore\r?\n(.*?)\r?\n```/s',
+            $commentBody,
+            $matches
+        );
+
+        if (!$matched) {
+            return null;
+        }
+
+        $lines = preg_split('/\r?\n/', trim($matches[1]));
+        $lines = array_values(array_filter(array_map('trim', $lines), function ($line) {
+            return $line !== '';
+        }));
+
+        if (empty($lines)) {
+            return null;
+        }
+
+        return $lines;
+    }
+}

--- a/Src/Tests/Library/InfisicalIgnoreApprovalCommentBuilderTest.php
+++ b/Src/Tests/Library/InfisicalIgnoreApprovalCommentBuilderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Tests\Library;
+
+use GuiBranco\GStracciniBot\Library\InfisicalIgnoreApprovalCommentBuilder;
+use PHPUnit\Framework\TestCase;
+
+class InfisicalIgnoreApprovalCommentBuilderTest extends TestCase
+{
+    private InfisicalIgnoreApprovalCommentBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new InfisicalIgnoreApprovalCommentBuilder();
+    }
+
+    public function testBuildIncludesMarkerWithOriginalCommentId(): void
+    {
+        $body = $this->builder->build("guibranco", "gstraccini-bot-service", 1112, 987654321);
+
+        $this->assertStringContainsString("<!-- gstraccini-bot:infisicalignore:987654321 -->", $body);
+    }
+
+    public function testBuildIncludesPermalinkToOriginalComment(): void
+    {
+        $body = $this->builder->build("guibranco", "gstraccini-bot-service", 1112, 987654321);
+
+        $this->assertStringContainsString(
+            "https://github.com/guibranco/gstraccini-bot-service/pull/1112#issuecomment-987654321",
+            $body
+        );
+    }
+
+    public function testBuildIncludesExactlyOneUncheckedCheckbox(): void
+    {
+        $body = $this->builder->build("guibranco", "gstraccini-bot-service", 1112, 987654321);
+
+        $this->assertSame(1, preg_match_all("/- \[ \] Apply this suggestion/", $body));
+        $this->assertSame(0, preg_match_all("/- \[x\] Apply this suggestion/i", $body));
+    }
+
+    public function testBuildCompletionIncludesCommitDetailsAndMarker(): void
+    {
+        $completion = $this->builder->buildCompletion("abcdef1", "Add suggested .infisicalignore entries");
+
+        $this->assertStringContainsString("<!-- gstraccini-bot:infisicalignore:applied -->", $completion);
+        $this->assertStringContainsString("✅ Suggestion successfully applied.", $completion);
+        $this->assertStringContainsString("abcdef1", $completion);
+    }
+}

--- a/Src/Tests/Library/InfisicalIgnoreFileUpdaterTest.php
+++ b/Src/Tests/Library/InfisicalIgnoreFileUpdaterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Tests\Library;
+
+use GuiBranco\GStracciniBot\Library\InfisicalIgnoreFileUpdater;
+use PHPUnit\Framework\TestCase;
+
+class InfisicalIgnoreFileUpdaterTest extends TestCase
+{
+    private InfisicalIgnoreFileUpdater $updater;
+
+    protected function setUp(): void
+    {
+        $this->updater = new InfisicalIgnoreFileUpdater();
+    }
+
+    public function testCreatesFileWhenNoExistingContent(): void
+    {
+        $result = $this->updater->merge(null, ["fingerprint-a", "fingerprint-b"]);
+
+        $this->assertSame("fingerprint-a\nfingerprint-b\n", $result);
+    }
+
+    public function testAppendsNewEntriesToExistingContent(): void
+    {
+        $existing = "existing-a\nexisting-b\n";
+
+        $result = $this->updater->merge($existing, ["new-c"]);
+
+        $this->assertSame("existing-a\nexisting-b\nnew-c\n", $result);
+    }
+
+    public function testDoesNotDuplicateEntriesAlreadyPresent(): void
+    {
+        $existing = "existing-a\nexisting-b\n";
+
+        $result = $this->updater->merge($existing, ["existing-b", "new-c"]);
+
+        $this->assertSame("existing-a\nexisting-b\nnew-c\n", $result);
+    }
+
+    public function testDedupesWithinNewLinesThemselves(): void
+    {
+        $result = $this->updater->merge(null, ["new-a", "new-a", "new-b"]);
+
+        $this->assertSame("new-a\nnew-b\n", $result);
+    }
+
+    public function testPreservesExistingLineOrder(): void
+    {
+        $existing = "z-line\na-line\n";
+
+        $result = $this->updater->merge($existing, ["new-line"]);
+
+        $this->assertSame("z-line\na-line\nnew-line\n", $result);
+    }
+}

--- a/Src/Tests/Library/InfisicalIgnoreSuggestionParserTest.php
+++ b/Src/Tests/Library/InfisicalIgnoreSuggestionParserTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Tests\Library;
+
+use GuiBranco\GStracciniBot\Library\InfisicalIgnoreSuggestionParser;
+use PHPUnit\Framework\TestCase;
+
+class InfisicalIgnoreSuggestionParserTest extends TestCase
+{
+    private InfisicalIgnoreSuggestionParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new InfisicalIgnoreSuggestionParser();
+    }
+
+    public function testParsesSingleLineSuggestion(): void
+    {
+        $body = "### Suggested update for `.infisicalignore`\n\n" .
+            "```suggestion:.infisicalignore\n" .
+            "616cdf6227a38caf6e9a1f2dc1f4ce33fc11d124:tests/endpoint-tests.sh:curl-auth-header:82\n" .
+            "```\n";
+
+        $result = $this->parser->parse($body);
+
+        $this->assertSame(
+            ["616cdf6227a38caf6e9a1f2dc1f4ce33fc11d124:tests/endpoint-tests.sh:curl-auth-header:82"],
+            $result
+        );
+    }
+
+    public function testParsesMultipleFingerprintLines(): void
+    {
+        $body = "```suggestion:.infisicalignore\n" .
+            "616cdf6227a38caf6e9a1f2dc1f4ce33fc11d124:tests/endpoint-tests.sh:curl-auth-header:82\n" .
+            "9098ba555a5fd5a04b2247f07f4e7d0812968684:public/openapi.yaml:generic-api-key:1439\n" .
+            "9098ba555a5fd5a04b2247f07f4e7d0812968684:public/openapi.yaml:generic-api-key:1618\n" .
+            "```\n";
+
+        $result = $this->parser->parse($body);
+
+        $this->assertCount(3, $result);
+        $this->assertSame("9098ba555a5fd5a04b2247f07f4e7d0812968684:public/openapi.yaml:generic-api-key:1618", $result[2]);
+    }
+
+    public function testReturnsNullWhenNoSuggestionFencePresent(): void
+    {
+        $result = $this->parser->parse("Just a regular comment with no suggestion block.");
+
+        $this->assertNull($result);
+    }
+
+    public function testReturnsNullWhenSuggestionBlockIsEmpty(): void
+    {
+        $body = "```suggestion:.infisicalignore\n\n```\n";
+
+        $result = $this->parser->parse($body);
+
+        $this->assertNull($result);
+    }
+
+    public function testIgnoresSurroundingMarkdown(): void
+    {
+        $body = "### Suggested update for `.infisicalignore`\n\n" .
+            "Apply this suggestion to ignore detected fingerprints:\n\n" .
+            "```suggestion:.infisicalignore\n" .
+            "616cdf6227a38caf6e9a1f2dc1f4ce33fc11d124:tests/endpoint-tests.sh:curl-auth-header:82\n" .
+            "```\n\n" .
+            "Some trailing note.\n";
+
+        $result = $this->parser->parse($body);
+
+        $this->assertSame(
+            ["616cdf6227a38caf6e9a1f2dc1f4ce33fc11d124:tests/endpoint-tests.sh:curl-auth-header:82"],
+            $result
+        );
+    }
+}


### PR DESCRIPTION
## 📑 Description
Introduce functionality to detect and respond to suggestions for updates to the `.infisicalignore` file made by `github-actions[bot]`. When such a suggestion is posted, the bot now adds an approval comment for maintainers to opt-in for the update. Upon approval, new entries are committed to the pull request branch.

- Added `InfisicalIgnoreApprovalCommentBuilder`, `InfisicalIgnoreSuggestionParser`, `InfisicalIgnoreCommitService`, and `InfisicalIgnoreFileUpdater` classes to handle the suggestion process.
- Implemented logic in `CommentsHandler` to detect suggestions, post approval comments, and apply approved updates.
- Added unit tests for the new components.

This enhancement streamlines the process, making it easier for maintainers to manage `.infisicalignore` updates, enhancing collaboration and efficiency.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Handle GitHub Actions suggestions for updating .infisicalignore via an approval-and-apply workflow in the comments handler.

New Features:
- Detect .infisicalignore suggestions posted by github-actions[bot] and post an approval checkbox comment for maintainers.
- Apply approved .infisicalignore suggestions by committing updates directly to the pull request branch via a dedicated commit service.

Enhancements:
- Extend the comments handler to react to edited bot comments and to avoid duplicating approval comments for the same suggestion.

Tests:
- Add unit tests for InfisicalIgnoreSuggestionParser, InfisicalIgnoreFileUpdater, and InfisicalIgnoreApprovalCommentBuilder to cover parsing, merge, and comment-building behaviors.