### PR TITLE
feat: implement notifications and actions for PR readiness

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,12 +11,19 @@
         "statusBar.background": "#007fff",
         "statusBar.foreground": "#e7e7e7",
         "statusBarItem.hoverBackground": "#3399ff",
-        "statusBarItem.remoteBackground": "#007fff",
+        "statusBarItem.remoteBackground": "#ff9fcf",
         "statusBarItem.remoteForeground": "#e7e7e7",
         "titleBar.activeBackground": "#007fff",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#007fff99",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "activityBarTop.activeBackground": "#3399ff",
+        "activityBarTop.background": "#3399ff",
+        "activityBarTop.foreground": "#15202b",
+        "activityBarTop.inactiveForeground": "#15202b99",
+        "commandCenter.foreground": "#e7e7e7",
+        "statusBar.debuggingBackground": "#007fff",
+        "statusBar.debuggingForeground": "#e7e7e7"
     },
     "peacock.color": "#007fff",
     "sonarlint.connectedMode.project": {

--- a/Sql/0008.recreate_notifications_and_pending_actions_tables.sql
+++ b/Sql/0008.recreate_notifications_and_pending_actions_tables.sql
@@ -1,0 +1,49 @@
+DROP TABLE IF EXISTS `pending_actions`;
+DROP TABLE IF EXISTS `notifications`;
+
+CREATE TABLE
+    `notifications` (
+        `Sequence` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `RepositoryOwner` VARCHAR(250) NOT NULL,
+        `RepositoryName` VARCHAR(250) NOT NULL,
+        `Type` VARCHAR(50) NOT NULL,
+        `Title` VARCHAR(255) NOT NULL,
+        `Message` TEXT NOT NULL,
+        `Url` VARCHAR(500) NULL,
+        `PullRequestId` BIGINT UNSIGNED NULL,
+        `PullRequestNumber` BIGINT UNSIGNED NULL,
+        `PullRequestNodeId` VARCHAR(250) NULL,
+        `IsRead` BOOLEAN NOT NULL DEFAULT FALSE,
+        `ReadAt` TIMESTAMP NULL,
+        `CreatedAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `UpdatedAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (`Sequence`)
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX idx_notifications_is_read ON notifications (`IsRead`);
+CREATE INDEX idx_notifications_pull_request_node_id ON notifications (`PullRequestNodeId`);
+
+CREATE TABLE
+    `pending_actions` (
+        `Sequence` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `NotificationSequence` BIGINT UNSIGNED NOT NULL,
+        `RepositoryOwner` VARCHAR(250) NOT NULL,
+        `RepositoryName` VARCHAR(250) NOT NULL,
+        `ActionType` VARCHAR(50) NOT NULL,
+        `Title` VARCHAR(255) NOT NULL,
+        `Description` TEXT NULL,
+        `Url` VARCHAR(500) NULL,
+        `PullRequestId` BIGINT UNSIGNED NULL,
+        `PullRequestNumber` BIGINT UNSIGNED NULL,
+        `PullRequestNodeId` VARCHAR(250) NULL,
+        `IsRead` BOOLEAN NOT NULL DEFAULT FALSE,
+        `ReadAt` TIMESTAMP NULL,
+        `CreatedAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `UpdatedAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (`Sequence`),
+        CONSTRAINT `fk_pending_actions_notification`
+            FOREIGN KEY (`NotificationSequence`) REFERENCES `notifications` (`Sequence`) ON DELETE CASCADE
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX idx_pending_actions_is_read ON pending_actions (`IsRead`);
+CREATE INDEX idx_pending_actions_pull_request_node_id ON pending_actions (`PullRequestNodeId`);

--- a/Src/Handlers/PullRequestsHandler.php
+++ b/Src/Handlers/PullRequestsHandler.php
@@ -57,6 +57,7 @@ class PullRequestsHandler implements IHandler
             $this->removeIssueWipLabel($metadata, $pullRequest);
             $this->removeLabels($metadata, $pullRequestUpdated);
             $this->checkForOtherPullRequests($metadata, $pullRequest);
+            removeUnreadActionsForPullRequest($pullRequestUpdated->node_id);
         }
 
         if ($pullRequestUpdated->state != "open") {
@@ -752,13 +753,12 @@ class PullRequestsHandler implements IHandler
         if ($pullRequestUpdated->mergeable_state === "clean" && $pullRequestUpdated->mergeable) {
             echo "State: " . $pullRequestUpdated->mergeable_state . " - Enable auto merge - Is mergeable - Sender auto merge: " . ($isSenderAutoMerge ? "✅" : "⛔") . " - Sender: " . $pullRequest->Sender . " ✅\n";
             $logStream?->info(
-                "PR #{$pullRequest->Number} is mergeable — posting ready-to-merge comment",
+                "PR #{$pullRequest->Number} is mergeable — recording ready-to-merge action",
                 ['repo' => "{$metadata['owner']}/{$metadata['repo']}", 'mergeable_state' => $pullRequestUpdated->mergeable_state, 'auto_merge_submitter' => $isSenderAutoMerge],
                 "pull_requests",
                 $pullRequest->DeliveryIdText
             );
-            $comment = array("body" => "<!-- gstraccini-bot:ready-merge -->\nThis pull request is ready ✅ for merge/squash.");
-            doRequestGitHub($metadata["token"], $metadata["commentsUrl"], $comment, "POST");
+            createReadyToMergeAction($pullRequest, $pullRequestUpdated);
         } else {
             echo "State: " . $pullRequestUpdated->mergeable_state . " - Enable auto merge - Is NOT mergeable - Sender auto merge: " . ($isSenderAutoMerge ? "✅" : "⛔") . " - Sender: " . $pullRequest->Sender . " ⛔\n";
             $logStream?->warning(

--- a/Src/api/v1/.htaccess
+++ b/Src/api/v1/.htaccess
@@ -10,8 +10,10 @@ RewriteRule ^ https://api.bot.straccini.com%{REQUEST_URI} [R=301,L]
 RewriteRule ^openapi\.yaml$ openapi.php [NC,L]
 
 # Redirect routes without trailing slash to canonical form
-RewriteRule ^(commands|health|swagger|stats)$ /v1/$1/ [R=301,NC,L]
+RewriteRule ^(commands|health|swagger|stats|pending-actions|notifications)$ /v1/$1/ [R=301,NC,L]
 RewriteRule ^jobs/([a-zA-Z]+)$ /v1/jobs/$1/ [R=301,NC,L]
+RewriteRule ^pending-actions/([0-9]+)/read$ /v1/pending-actions/$1/read/ [R=301,NC,L]
+RewriteRule ^notifications/([0-9]+)/read$ /v1/notifications/$1/read/ [R=301,NC,L]
 
 # Route trailing-slash requests to PHP handlers
 RewriteRule ^commands/$ commands.php [NC,L]
@@ -19,3 +21,7 @@ RewriteRule ^health/$ health.php [NC,L]
 RewriteRule ^swagger/$ swagger.php [NC,L]
 RewriteRule ^stats/$ stats.php [NC,L]
 RewriteRule ^jobs/([a-zA-Z]+)/$ jobs.php [NC,L]
+RewriteRule ^pending-actions/$ pendingActions.php [NC,L]
+RewriteRule ^pending-actions/([0-9]+)/read/$ pendingActions.php [NC,L]
+RewriteRule ^notifications/$ notifications.php [NC,L]
+RewriteRule ^notifications/([0-9]+)/read/$ notifications.php [NC,L]

--- a/Src/api/v1/notifications.php
+++ b/Src/api/v1/notifications.php
@@ -1,0 +1,129 @@
+<?php
+
+// Notifications endpoint - lists unread notifications for the UI,
+// and lets the UI flag a specific one as read.
+
+header('Content-Type: application/json');
+
+$apiSecretsFile = __DIR__ . '/secrets/api.secrets.php';
+if (file_exists($apiSecretsFile)) {
+    require_once $apiSecretsFile;
+}
+
+$providedKey = $_SERVER['HTTP_X_API_KEY'] ?? '';
+if (empty($providedKey) || !isset($apiKey) || !hash_equals($apiKey, $providedKey)) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+if (!isset($workerDir) || !is_dir($workerDir)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Worker directory not configured']);
+    exit;
+}
+
+require_once $workerDir . '/Library/DatabaseHandler.php';
+
+$mySqlSecretsFile = $workerDir . '/secrets/mySql.secrets.php';
+if (file_exists($mySqlSecretsFile)) {
+    require_once $mySqlSecretsFile;
+}
+
+if (!isset($mySqlHost, $mySqlUser, $mySqlPassword, $mySqlDatabase)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database not configured']);
+    exit;
+}
+
+$dbHandler = new DatabaseHandler($mySqlHost, $mySqlUser, $mySqlPassword, $mySqlDatabase);
+
+try {
+    $mysqli = $dbHandler->connect();
+} catch (\Exception $e) {
+    http_response_code(503);
+    echo json_encode(['error' => 'Database unavailable']);
+    exit;
+}
+
+$segments = array_values(array_filter(explode('/', parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))));
+$resourceIndex = array_search('notifications', $segments, true);
+$sequence = $resourceIndex !== false ? ($segments[$resourceIndex + 1] ?? null) : null;
+$isReadAction = $resourceIndex !== false && ($segments[$resourceIndex + 2] ?? null) === 'read';
+
+if ($sequence !== null && $isReadAction) {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        http_response_code(405);
+        header('Allow: POST');
+        echo json_encode(['error' => 'Method Not Allowed']);
+        $mysqli->close();
+        exit;
+    }
+
+    if (!ctype_digit($sequence)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid sequence']);
+        $mysqli->close();
+        exit;
+    }
+
+    $sequenceInt = (int) $sequence;
+    $stmt = $mysqli->prepare("UPDATE notifications SET IsRead = TRUE, ReadAt = NOW() WHERE Sequence = ? AND IsRead = FALSE");
+    $stmt->bind_param("i", $sequenceInt);
+    $stmt->execute();
+    $updated = $stmt->affected_rows === 1;
+    $stmt->close();
+    $mysqli->close();
+
+    if (!$updated) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Notification not found or already read']);
+        exit;
+    }
+
+    http_response_code(200);
+    echo json_encode(['status' => 'read', 'sequence' => $sequenceInt]);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    header('Allow: GET');
+    echo json_encode(['error' => 'Method Not Allowed']);
+    $mysqli->close();
+    exit;
+}
+
+$result = $mysqli->query(
+    "SELECT Sequence, RepositoryOwner, RepositoryName, Type, Title, Message, Url,
+        PullRequestId, PullRequestNumber, PullRequestNodeId, IsRead, CreatedAt
+     FROM notifications
+     WHERE IsRead = FALSE
+     ORDER BY CreatedAt DESC"
+);
+
+$notifications = [];
+if ($result) {
+    while ($row = $result->fetch_assoc()) {
+        $notifications[] = [
+            'sequence' => (int) $row['Sequence'],
+            'repositoryOwner' => $row['RepositoryOwner'],
+            'repositoryName' => $row['RepositoryName'],
+            'type' => $row['Type'],
+            'title' => $row['Title'],
+            'message' => $row['Message'],
+            'url' => $row['Url'],
+            'pullRequestId' => $row['PullRequestId'] !== null ? (int) $row['PullRequestId'] : null,
+            'pullRequestNumber' => $row['PullRequestNumber'] !== null ? (int) $row['PullRequestNumber'] : null,
+            'pullRequestNodeId' => $row['PullRequestNodeId'],
+            'isRead' => (bool) $row['IsRead'],
+            'createdAt' => $row['CreatedAt'],
+        ];
+    }
+    $result->close();
+}
+
+$mysqli->close();
+
+http_response_code(200);
+echo json_encode($notifications);

--- a/Src/api/v1/openapi.yaml
+++ b/Src/api/v1/openapi.yaml
@@ -21,6 +21,10 @@ tags:
     description: Trigger background processing jobs
   - name: Stats
     description: Aggregate usage statistics
+  - name: Pending Actions
+    description: Actions awaiting attention in the UI (e.g. pull requests ready to merge)
+  - name: Notifications
+    description: Notifications surfaced to the UI
 paths:
   /health/:
     get:
@@ -157,6 +161,184 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /pending-actions/:
+    get:
+      summary: List unread pending actions
+      description: Returns pending actions (e.g. pull requests ready to merge) that have not yet been read
+      operationId: getPendingActions
+      tags:
+        - Pending Actions
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: List of unread pending actions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PendingAction'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '405':
+          description: Method not allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Database not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Database unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pending-actions/{sequence}/read/:
+    post:
+      summary: Mark a pending action as read
+      description: Flags a pending action as read so it stops showing up in the unread list
+      operationId: markPendingActionRead
+      tags:
+        - Pending Actions
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: sequence
+          in: path
+          required: true
+          description: Sequence identifier of the pending action
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pending action marked as read
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadAck'
+        '400':
+          description: Invalid sequence
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Pending action not found or already read
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '405':
+          description: Method not allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notifications/:
+    get:
+      summary: List unread notifications
+      description: Returns notifications that have not yet been read
+      operationId: getNotifications
+      tags:
+        - Notifications
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: List of unread notifications
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Notification'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '405':
+          description: Method not allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Database not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Database unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notifications/{sequence}/read/:
+    post:
+      summary: Mark a notification as read
+      description: Flags a notification as read so it stops showing up in the unread list
+      operationId: markNotificationRead
+      tags:
+        - Notifications
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: sequence
+          in: path
+          required: true
+          description: Sequence identifier of the notification
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Notification marked as read
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadAck'
+        '400':
+          description: Invalid sequence
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Notification not found or already read
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '405':
+          description: Method not allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -246,3 +428,95 @@ components:
         activeRepositories:
           type: integer
           example: 6
+    PendingAction:
+      type: object
+      properties:
+        sequence:
+          type: integer
+          example: 42
+        repositoryOwner:
+          type: string
+          example: guibranco
+        repositoryName:
+          type: string
+          example: gstraccini-bot-service
+        actionType:
+          type: string
+          example: pull_request_ready_to_merge
+        title:
+          type: string
+          example: Pull request ready for merge/squash
+        description:
+          type: string
+          nullable: true
+          example: "\"Add check-up job\" (#1120) is ready ✅ for merge/squash."
+        url:
+          type: string
+          nullable: true
+          example: https://github.com/guibranco/gstraccini-bot-service/pull/1120
+        pullRequestId:
+          type: integer
+          nullable: true
+        pullRequestNumber:
+          type: integer
+          nullable: true
+          example: 1120
+        pullRequestNodeId:
+          type: string
+          nullable: true
+        isRead:
+          type: boolean
+          example: false
+        createdAt:
+          type: string
+          format: date-time
+    Notification:
+      type: object
+      properties:
+        sequence:
+          type: integer
+          example: 42
+        repositoryOwner:
+          type: string
+          example: guibranco
+        repositoryName:
+          type: string
+          example: gstraccini-bot-service
+        type:
+          type: string
+          example: pull_request_ready_to_merge
+        title:
+          type: string
+          example: Pull request ready for merge/squash
+        message:
+          type: string
+          example: "\"Add check-up job\" (#1120) is ready ✅ for merge/squash."
+        url:
+          type: string
+          nullable: true
+          example: https://github.com/guibranco/gstraccini-bot-service/pull/1120
+        pullRequestId:
+          type: integer
+          nullable: true
+        pullRequestNumber:
+          type: integer
+          nullable: true
+          example: 1120
+        pullRequestNodeId:
+          type: string
+          nullable: true
+        isRead:
+          type: boolean
+          example: false
+        createdAt:
+          type: string
+          format: date-time
+    ReadAck:
+      type: object
+      properties:
+        status:
+          type: string
+          example: read
+        sequence:
+          type: integer
+          example: 42

--- a/Src/api/v1/pendingActions.php
+++ b/Src/api/v1/pendingActions.php
@@ -1,0 +1,129 @@
+<?php
+
+// Pending actions endpoint - lists unread pending actions for the UI,
+// and lets the UI flag a specific one as read.
+
+header('Content-Type: application/json');
+
+$apiSecretsFile = __DIR__ . '/secrets/api.secrets.php';
+if (file_exists($apiSecretsFile)) {
+    require_once $apiSecretsFile;
+}
+
+$providedKey = $_SERVER['HTTP_X_API_KEY'] ?? '';
+if (empty($providedKey) || !isset($apiKey) || !hash_equals($apiKey, $providedKey)) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+if (!isset($workerDir) || !is_dir($workerDir)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Worker directory not configured']);
+    exit;
+}
+
+require_once $workerDir . '/Library/DatabaseHandler.php';
+
+$mySqlSecretsFile = $workerDir . '/secrets/mySql.secrets.php';
+if (file_exists($mySqlSecretsFile)) {
+    require_once $mySqlSecretsFile;
+}
+
+if (!isset($mySqlHost, $mySqlUser, $mySqlPassword, $mySqlDatabase)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database not configured']);
+    exit;
+}
+
+$dbHandler = new DatabaseHandler($mySqlHost, $mySqlUser, $mySqlPassword, $mySqlDatabase);
+
+try {
+    $mysqli = $dbHandler->connect();
+} catch (\Exception $e) {
+    http_response_code(503);
+    echo json_encode(['error' => 'Database unavailable']);
+    exit;
+}
+
+$segments = array_values(array_filter(explode('/', parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))));
+$resourceIndex = array_search('pending-actions', $segments, true);
+$sequence = $resourceIndex !== false ? ($segments[$resourceIndex + 1] ?? null) : null;
+$isReadAction = $resourceIndex !== false && ($segments[$resourceIndex + 2] ?? null) === 'read';
+
+if ($sequence !== null && $isReadAction) {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        http_response_code(405);
+        header('Allow: POST');
+        echo json_encode(['error' => 'Method Not Allowed']);
+        $mysqli->close();
+        exit;
+    }
+
+    if (!ctype_digit($sequence)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid sequence']);
+        $mysqli->close();
+        exit;
+    }
+
+    $sequenceInt = (int) $sequence;
+    $stmt = $mysqli->prepare("UPDATE pending_actions SET IsRead = TRUE, ReadAt = NOW() WHERE Sequence = ? AND IsRead = FALSE");
+    $stmt->bind_param("i", $sequenceInt);
+    $stmt->execute();
+    $updated = $stmt->affected_rows === 1;
+    $stmt->close();
+    $mysqli->close();
+
+    if (!$updated) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Pending action not found or already read']);
+        exit;
+    }
+
+    http_response_code(200);
+    echo json_encode(['status' => 'read', 'sequence' => $sequenceInt]);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    header('Allow: GET');
+    echo json_encode(['error' => 'Method Not Allowed']);
+    $mysqli->close();
+    exit;
+}
+
+$result = $mysqli->query(
+    "SELECT Sequence, RepositoryOwner, RepositoryName, ActionType, Title, Description, Url,
+        PullRequestId, PullRequestNumber, PullRequestNodeId, IsRead, CreatedAt
+     FROM pending_actions
+     WHERE IsRead = FALSE
+     ORDER BY CreatedAt DESC"
+);
+
+$pendingActions = [];
+if ($result) {
+    while ($row = $result->fetch_assoc()) {
+        $pendingActions[] = [
+            'sequence' => (int) $row['Sequence'],
+            'repositoryOwner' => $row['RepositoryOwner'],
+            'repositoryName' => $row['RepositoryName'],
+            'actionType' => $row['ActionType'],
+            'title' => $row['Title'],
+            'description' => $row['Description'],
+            'url' => $row['Url'],
+            'pullRequestId' => $row['PullRequestId'] !== null ? (int) $row['PullRequestId'] : null,
+            'pullRequestNumber' => $row['PullRequestNumber'] !== null ? (int) $row['PullRequestNumber'] : null,
+            'pullRequestNodeId' => $row['PullRequestNodeId'],
+            'isRead' => (bool) $row['IsRead'],
+            'createdAt' => $row['CreatedAt'],
+        ];
+    }
+    $result->close();
+}
+
+$mysqli->close();
+
+http_response_code(200);
+echo json_encode($pendingActions);

--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -225,6 +225,109 @@ function upsertPullRequest($pullRequest)
     $mysqli->close();
 }
 
+const ACTION_TYPE_PULL_REQUEST_READY_TO_MERGE = "pull_request_ready_to_merge";
+
+/**
+ * Creates a "ready to merge" notification and pending action for a pull request,
+ * unless an unread one already exists for the same pull request.
+ *
+ * @param object $pullRequest The queued pull request event (RepositoryOwner, RepositoryName).
+ * @param object $pullRequestUpdated The freshly fetched pull request data from the GitHub API.
+ * @return void
+ */
+function createReadyToMergeAction($pullRequest, $pullRequestUpdated): void
+{
+    $mysqli = connectToDatabase();
+
+    $sql = "SELECT Sequence FROM notifications WHERE PullRequestNodeId = ? AND Type = ? AND IsRead = FALSE";
+    $stmt = $mysqli->prepare($sql);
+    $nodeId = $pullRequestUpdated->node_id;
+    $type = ACTION_TYPE_PULL_REQUEST_READY_TO_MERGE;
+    $stmt->bind_param("ss", $nodeId, $type);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $exists = $result->fetch_assoc() !== null;
+    $stmt->close();
+
+    if ($exists) {
+        $mysqli->close();
+        return;
+    }
+
+    $title = "Pull request ready for merge/squash";
+    $message = "\"{$pullRequestUpdated->title}\" (#{$pullRequestUpdated->number}) is ready ✅ for merge/squash.";
+
+    $sql = "INSERT INTO notifications
+        (`RepositoryOwner`, `RepositoryName`, `Type`, `Title`, `Message`, `Url`, `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param(
+        "ssssssiis",
+        $pullRequest->RepositoryOwner,
+        $pullRequest->RepositoryName,
+        $type,
+        $title,
+        $message,
+        $pullRequestUpdated->html_url,
+        $pullRequestUpdated->id,
+        $pullRequestUpdated->number,
+        $nodeId
+    );
+
+    if (!$stmt->execute()) {
+        die("Execute failed: (" . $stmt->errno . ") " . $stmt->error);
+    }
+
+    $notificationSequence = $stmt->insert_id;
+    $stmt->close();
+
+    $sql = "INSERT INTO pending_actions
+        (`NotificationSequence`, `RepositoryOwner`, `RepositoryName`, `ActionType`, `Title`, `Description`, `Url`, `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param(
+        "issssssiis",
+        $notificationSequence,
+        $pullRequest->RepositoryOwner,
+        $pullRequest->RepositoryName,
+        $type,
+        $title,
+        $message,
+        $pullRequestUpdated->html_url,
+        $pullRequestUpdated->id,
+        $pullRequestUpdated->number,
+        $nodeId
+    );
+
+    if (!$stmt->execute()) {
+        die("Execute failed: (" . $stmt->errno . ") " . $stmt->error);
+    }
+
+    $stmt->close();
+    $mysqli->close();
+}
+
+/**
+ * Removes unread notifications (and their cascaded pending actions) for a pull request.
+ * Called when a pull request is closed or merged, so stale actions don't linger
+ * once they are no longer actionable. Read items are left untouched as history.
+ *
+ * @param string $pullRequestNodeId The GraphQL node ID of the pull request.
+ * @return void
+ */
+function removeUnreadActionsForPullRequest($pullRequestNodeId): void
+{
+    $mysqli = connectToDatabase();
+
+    $sql = "DELETE FROM notifications WHERE PullRequestNodeId = ? AND IsRead = FALSE";
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param("s", $pullRequestNodeId);
+    $stmt->execute();
+
+    $stmt->close();
+    $mysqli->close();
+}
+
 function upsertPush($commit)
 {
     $mysqli = connectToDatabase();


### PR DESCRIPTION
## 📑 Description
Add database tables for notifications and pending actions to track unread updates for pull requests ready to merge. Create new endpoints in the API to manage and mark notifications and actions as read.

These changes enhance the user experience by allowing real-time tracking and acknowledgment of pending tasks and alerts within the user interface, promoting more dynamic interaction with notifications.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Introduce database-backed notifications and pending actions for pull requests and expose them via authenticated API endpoints for listing unread items and marking them as read.

New Features:
- Add REST API endpoints to list unread notifications and pending actions and to mark individual items as read.
- Track ready-to-merge pull requests as notifications and pending actions instead of posting GitHub comments.

Enhancements:
- Automatically create a notification and pending action when a pull request becomes cleanly mergeable, and remove unread items when the pull request is closed or merged.
- Document the new notifications and pending actions APIs and schemas in the OpenAPI specification.

Chores:
- Add SQL migration to recreate notifications and pending_actions tables with read-tracking metadata and foreign key relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for viewing unread notifications and pending actions.
  * Added support for marking individual notifications and pending actions as read.
  * Added ready-to-merge actions for pull requests.

* **Bug Fixes**
  * Unread pull request actions are now cleared when a pull request is closed.

* **Documentation**
  * Updated API documentation with the new endpoints and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->