### PR TITLE
feat: support version bump decision comments +semver: minor

### DIFF
--- a/Src/Handlers/CommentsHandler.php
+++ b/Src/Handlers/CommentsHandler.php
@@ -10,6 +10,8 @@ use GuiBranco\GStracciniBot\Library\InfisicalIgnoreSuggestionParser;
 use GuiBranco\GStracciniBot\Library\LabelHelper;
 use GuiBranco\GStracciniBot\Library\LabelService;
 use GuiBranco\GStracciniBot\Library\RepositoryManager;
+use GuiBranco\GStracciniBot\Library\VersionBumpCommentBuilder;
+use GuiBranco\GStracciniBot\Library\VersionBumpCommitService;
 use RuntimeException;
 
 /**
@@ -80,6 +82,7 @@ class CommentsHandler implements IHandler
         if ($action === "edited" && $sender === $config->botName . "[bot]") {
             $metadata = $this->buildMetadata($comment, $config);
             $this->execute_applyInfisicalIgnoreSuggestion($config, $metadata, $comment);
+            $this->execute_applyVersionBumpDecision($config, $metadata, $comment);
             return;
         }
 
@@ -1184,6 +1187,112 @@ class CommentsHandler implements IHandler
 
         $completion = $builder->buildCompletion($result["sha"] ?? "n/a", $result["message"]);
         doRequestGitHub($metadata["token"], $approvalCommentUrl, array("body" => $body . $completion), "PATCH");
+    }
+
+    /**
+     * Handles an edit to the bot's own version-bump decision comment: once the user
+     * checks one of the three options, either resolves the pending "GStraccini Checks:
+     * Pull Request" check run directly (no version bump), or pushes a dummy commit
+     * carrying the matching `+semver` directive (minor/major), letting the next
+     * pull_request synchronize event resolve the check run naturally.
+     */
+    private function execute_applyVersionBumpDecision($config, $metadata, $comment): void
+    {
+        $commentUrl = "{$metadata['repoPrefix']}/issues/comments/{$comment->CommentId}";
+        $response = doRequestGitHub($metadata["token"], $commentUrl, null, "GET");
+        if ($response->getStatusCode() !== 200) {
+            return;
+        }
+
+        $existingComment = json_decode($response->getBody());
+        $body = $existingComment->body;
+
+        if (stripos($body, VersionBumpCommentBuilder::MARKER) === false) {
+            return;
+        }
+
+        if (stripos($body, VersionBumpCommentBuilder::COMPLETION_MARKER) !== false) {
+            return;
+        }
+
+        $choice = $this->extractVersionBumpChoice($body);
+        if ($choice === null) {
+            return;
+        }
+
+        $pullRequestResponse = doRequestGitHub($metadata["token"], $metadata["pullRequestUrl"], null, "GET");
+        if ($pullRequestResponse->getStatusCode() !== 200) {
+            return;
+        }
+        $pullRequest = json_decode($pullRequestResponse->getBody());
+
+        $builder = new VersionBumpCommentBuilder();
+
+        if ($choice === "none") {
+            $this->resolveVersionBumpCheckRun($metadata, $pullRequest->head->sha, "No version bump requested by the user.");
+            $completion = $builder->buildCompletion("No version bump");
+            doRequestGitHub($metadata["token"], $commentUrl, array("body" => $body . $completion), "PATCH");
+            return;
+        }
+
+        $message = "Apply requested {$choice} version bump\n\n+semver: {$choice}";
+
+        $commitService = new VersionBumpCommitService();
+        try {
+            $result = $commitService->createDummyCommit($metadata, $pullRequest->head->ref, $pullRequest->head->sha, $message);
+        } catch (RuntimeException $e) {
+            $failureBody = $body . "\n\n❌ Failed to apply version bump: " . $e->getMessage() . "\n";
+            doRequestGitHub($metadata["token"], $commentUrl, array("body" => $failureBody), "PATCH");
+            return;
+        }
+
+        $completion = $builder->buildCompletion(ucfirst($choice) . " version bump", $result["sha"]);
+        doRequestGitHub($metadata["token"], $commentUrl, array("body" => $body . $completion), "PATCH");
+    }
+
+    /**
+     * Determines which version-bump checkbox, if any, is checked in the given comment body.
+     *
+     * @return string|null "major", "minor", "none", or null if none is checked.
+     */
+    private function extractVersionBumpChoice(string $body): ?string
+    {
+        $options = [
+            "major" => VersionBumpCommentBuilder::CHECKBOX_MAJOR,
+            "minor" => VersionBumpCommentBuilder::CHECKBOX_MINOR,
+            "none" => VersionBumpCommentBuilder::CHECKBOX_NONE,
+        ];
+
+        foreach ($options as $choice => $label) {
+            $quotedLabel = preg_quote($label, "/");
+            if (preg_match("/-\s\[(x|X)\]\s{$quotedLabel}/", $body)) {
+                return $choice;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the still-pending "GStraccini Checks: Pull Request" check run for the
+     * given commit sha, marking it succeeded.
+     */
+    private function resolveVersionBumpCheckRun($metadata, string $sha, string $details): void
+    {
+        $url = "{$metadata['repoPrefix']}/commits/{$sha}/check-runs";
+        $response = doRequestGitHub($metadata["token"], $url, null, "GET");
+        if ($response->getStatusCode() !== 200) {
+            return;
+        }
+
+        $result = json_decode($response->getBody());
+        $checkRunName = constant("BOT_CHECK_MESSAGE_PREFIX") . "Pull Request";
+
+        foreach ($result->check_runs as $checkRun) {
+            if ($checkRun->name === $checkRunName && $checkRun->status !== "completed") {
+                setCheckRunSucceeded($metadata, $checkRun->id, "pull request", $details);
+            }
+        }
     }
 
     /**

--- a/Src/Handlers/PullRequestsHandler.php
+++ b/Src/Handlers/PullRequestsHandler.php
@@ -5,6 +5,8 @@ namespace GuiBranco\GStracciniBot\Handlers;
 use GuiBranco\GStracciniBot\Library\DependencyFileLabelService;
 use GuiBranco\GStracciniBot\Library\MarkdownGroupCheckboxValidator;
 use GuiBranco\GStracciniBot\Library\PullRequestCodeScanner;
+use GuiBranco\GStracciniBot\Library\VersionBumpAnalyzer;
+use GuiBranco\GStracciniBot\Library\VersionBumpCommentBuilder;
 
 define("ISSUES", "/issues/");
 define("PULLS", "/pulls/");
@@ -159,10 +161,58 @@ class PullRequestsHandler implements IHandler
             $this->handleCommentToMerge($metadata, $pullRequest, $collaboratorsLogins);
         }
 
+        $versionBumpResolved = $this->checkVersionBump($metadata, $pullRequestUpdated);
+
         $this->checkPullRequestDescription($metadata, $pullRequestUpdated);
         $this->checkPullRequestContent($metadata, $pullRequestUpdated);
         $this->checkDependencyChanges($metadata, $pullRequestUpdated);
-        setCheckRunSucceeded($metadata, $checkRunId, "pull request");
+
+        if ($versionBumpResolved) {
+            setCheckRunSucceeded($metadata, $checkRunId, "pull request");
+        } else {
+            echo "State: Version bump decision pending - leaving 'pull request' check run in progress ⏳\n";
+        }
+    }
+
+    /**
+     * Analyzes a pull request for a version bump decision: if it looks like a feature
+     * (via title, branch name, or labels) and no GitVersion `+semver` directive is
+     * already present in its title or commits, an actionable comment is posted asking
+     * the user to choose a minor bump, a major bump, or no bump at all.
+     *
+     * @param array $metadata Metadata for the GitHub API request
+     * @param object $pullRequestUpdated The updated pull request data
+     * @return bool True if the decision is resolved (no action needed, or already handled),
+     *              false if it's still pending user input.
+     */
+    private function checkVersionBump(array $metadata, object $pullRequestUpdated): bool
+    {
+        $analyzer = new VersionBumpAnalyzer();
+
+        $messages = [$pullRequestUpdated->title];
+        $commitsResponse = doRequestGitHub($metadata["token"], $metadata["pullRequestUrl"] . "/commits", null, "GET");
+        if ($commitsResponse->getStatusCode() < 300) {
+            foreach (json_decode($commitsResponse->getBody()) as $commit) {
+                $messages[] = $commit->commit->message;
+            }
+        }
+
+        if ($analyzer->hasSemverDirective($messages)) {
+            return true;
+        }
+
+        $labels = array_column($pullRequestUpdated->labels ?? [], "name");
+        if (!$analyzer->looksLikeFeature($pullRequestUpdated->title, $pullRequestUpdated->head->ref, $labels)) {
+            return true;
+        }
+
+        if (!$this->findCommentByContent($metadata, $pullRequestUpdated, VersionBumpCommentBuilder::MARKER)) {
+            $builder = new VersionBumpCommentBuilder();
+            $body = $builder->build($pullRequestUpdated->title);
+            doRequestGitHub($metadata["token"], $metadata["commentsUrl"], array("body" => $body), "POST");
+        }
+
+        return false;
     }
 
     /**

--- a/Src/Library/VersionBumpAnalyzer.php
+++ b/Src/Library/VersionBumpAnalyzer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+/**
+ * Detects whether a pull request looks like a feature change, and whether
+ * it (or its commits) already carries a GitVersion `+semver` directive.
+ */
+class VersionBumpAnalyzer
+{
+    private const FEATURE_PATTERN = '/\bfeat(?:ure)?\b/i';
+    private const SEMVER_PATTERN = '/\+semver:\s?(major|breaking|minor|feature|patch|fix|none|skip)/i';
+
+    /**
+     * @param string $title The pull request title.
+     * @param string $branch The pull request head branch name.
+     * @param string[] $labels Names of labels applied to the pull request.
+     */
+    public function looksLikeFeature(string $title, string $branch, array $labels): bool
+    {
+        if (preg_match(self::FEATURE_PATTERN, $title) || preg_match(self::FEATURE_PATTERN, $branch)) {
+            return true;
+        }
+
+        foreach ($labels as $label) {
+            if (preg_match(self::FEATURE_PATTERN, $label)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string[] $messages Text to scan for a `+semver:` directive (e.g. the PR title
+     *                           plus each commit message in the pull request).
+     */
+    public function hasSemverDirective(array $messages): bool
+    {
+        foreach ($messages as $message) {
+            if (preg_match(self::SEMVER_PATTERN, $message)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Src/Library/VersionBumpCommentBuilder.php
+++ b/Src/Library/VersionBumpCommentBuilder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+/**
+ * Builds the actionable comment asking a maintainer to choose a version bump
+ * for a feature-looking pull request, and the completion note appended once
+ * a choice has been applied.
+ */
+class VersionBumpCommentBuilder
+{
+    public const MARKER = "<!-- gstraccini-bot:semver-decision -->";
+    public const COMPLETION_MARKER = "<!-- gstraccini-bot:semver-decision:applied -->";
+    public const CHECKBOX_MAJOR = "Major version bump (`+semver: major`, breaking change)";
+    public const CHECKBOX_MINOR = "Minor version bump (`+semver: minor`)";
+    public const CHECKBOX_NONE = "No version bump";
+
+    public function build(string $pullRequestTitle): string
+    {
+        $body = self::MARKER . "\n";
+        $body .= "### Version bump needed\n\n";
+        $body .= "\"{$pullRequestTitle}\" looks like a **feature** change (based on its title, branch name, or labels), ";
+        $body .= "but I couldn't find a GitVersion `+semver` directive in its commits.\n\n";
+        $body .= "Please choose how this should affect the version:\n\n";
+        $body .= "- [ ] " . self::CHECKBOX_MAJOR . "\n";
+        $body .= "- [ ] " . self::CHECKBOX_MINOR . "\n";
+        $body .= "- [ ] " . self::CHECKBOX_NONE . "\n\n";
+        $body .= "Check one box to continue. I'll push a commit with the appropriate `+semver` tag " .
+            "(or unblock the check directly, for no version bump) once you do.\n\n";
+        $body .= "This is part of the overall **GStraccini Checks: Pull Request** check run, " .
+            "which will stay in progress until one option is selected.\n";
+
+        return $body;
+    }
+
+    public function buildCompletion(string $choiceLabel, ?string $commitSha = null): string
+    {
+        $completion = "\n\n" . self::COMPLETION_MARKER . "\n";
+        $completion .= "✅ {$choiceLabel} applied.\n";
+        if ($commitSha !== null) {
+            $completion .= "\nCommit: `{$commitSha}`\n";
+        }
+
+        return $completion;
+    }
+}

--- a/Src/Library/VersionBumpCommitService.php
+++ b/Src/Library/VersionBumpCommitService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Library;
+
+use RuntimeException;
+
+/**
+ * Pushes an empty ("dummy") commit onto a pull request branch via the GitHub
+ * Git Data API, so a `+semver:` directive can be recorded without touching
+ * any file content. This service does not use a local git checkout — it
+ * only issues GitHub API calls.
+ */
+class VersionBumpCommitService
+{
+    public function createDummyCommit(array $metadata, string $branch, string $headSha, string $message): array
+    {
+        $commitUrl = "{$metadata['repoPrefix']}/git/commits/{$headSha}";
+        $commitResponse = doRequestGitHub($metadata["token"], $commitUrl, null, "GET");
+        if ($commitResponse->getStatusCode() !== 200) {
+            throw new RuntimeException(
+                "Failed to read head commit: [{$commitResponse->getStatusCode()}] " . $commitResponse->getBody()
+            );
+        }
+
+        $commit = json_decode($commitResponse->getBody());
+        $treeSha = $commit->tree->sha;
+
+        $newCommitBody = [
+            "message" => $message,
+            "tree" => $treeSha,
+            "parents" => [$headSha],
+        ];
+        $newCommitUrl = "{$metadata['repoPrefix']}/git/commits";
+        $newCommitResponse = doRequestGitHub($metadata["token"], $newCommitUrl, $newCommitBody, "POST");
+        if ($newCommitResponse->getStatusCode() !== 201) {
+            throw new RuntimeException(
+                "Failed to create commit: [{$newCommitResponse->getStatusCode()}] " . $newCommitResponse->getBody()
+            );
+        }
+
+        $newCommit = json_decode($newCommitResponse->getBody());
+        $newSha = $newCommit->sha;
+
+        $refUrl = "{$metadata['repoPrefix']}/git/refs/heads/{$branch}";
+        $refResponse = doRequestGitHub($metadata["token"], $refUrl, ["sha" => $newSha], "PATCH");
+        if ($refResponse->getStatusCode() !== 200) {
+            throw new RuntimeException(
+                "Failed to update branch ref: [{$refResponse->getStatusCode()}] " . $refResponse->getBody()
+            );
+        }
+
+        return ["sha" => $newSha];
+    }
+}

--- a/Src/Tests/Library/VersionBumpAnalyzerTest.php
+++ b/Src/Tests/Library/VersionBumpAnalyzerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Tests\Library;
+
+use GuiBranco\GStracciniBot\Library\VersionBumpAnalyzer;
+use PHPUnit\Framework\TestCase;
+
+class VersionBumpAnalyzerTest extends TestCase
+{
+    private VersionBumpAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new VersionBumpAnalyzer();
+    }
+
+    public function testLooksLikeFeatureFromTitle(): void
+    {
+        $this->assertTrue($this->analyzer->looksLikeFeature("feat: add new dashboard", "fix/123", []));
+        $this->assertTrue($this->analyzer->looksLikeFeature("Add a new feature", "chore/123", []));
+    }
+
+    public function testLooksLikeFeatureFromBranchName(): void
+    {
+        $this->assertTrue($this->analyzer->looksLikeFeature("Add dashboard", "feature/new-dashboard", []));
+        $this->assertTrue($this->analyzer->looksLikeFeature("Add dashboard", "feat/new-dashboard", []));
+    }
+
+    public function testLooksLikeFeatureFromLabels(): void
+    {
+        $this->assertTrue($this->analyzer->looksLikeFeature("Add dashboard", "chore/123", ["enhancement", "feature"]));
+    }
+
+    public function testDoesNotLookLikeFeature(): void
+    {
+        $this->assertFalse($this->analyzer->looksLikeFeature("Fix null pointer bug", "fix/123", ["bug"]));
+    }
+
+    public function testDoesNotFalsePositiveOnUnrelatedWords(): void
+    {
+        $this->assertFalse($this->analyzer->looksLikeFeature("Update featherweight dependency", "chore/deps", []));
+    }
+
+    public function testHasSemverDirectiveDetectsMinor(): void
+    {
+        $this->assertTrue($this->analyzer->hasSemverDirective(["Add check-up job +semver:minor"]));
+        $this->assertTrue($this->analyzer->hasSemverDirective(["Some message", "+semver: feature"]));
+    }
+
+    public function testHasSemverDirectiveDetectsMajor(): void
+    {
+        $this->assertTrue($this->analyzer->hasSemverDirective(["Breaking change +semver: major"]));
+        $this->assertTrue($this->analyzer->hasSemverDirective(["Breaking change +semver:breaking"]));
+    }
+
+    public function testHasSemverDirectiveReturnsFalseWhenAbsent(): void
+    {
+        $this->assertFalse($this->analyzer->hasSemverDirective(["Add new feature", "Fix typo"]));
+    }
+}

--- a/Src/Tests/Library/VersionBumpCommentBuilderTest.php
+++ b/Src/Tests/Library/VersionBumpCommentBuilderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GuiBranco\GStracciniBot\Tests\Library;
+
+use GuiBranco\GStracciniBot\Library\VersionBumpCommentBuilder;
+use PHPUnit\Framework\TestCase;
+
+class VersionBumpCommentBuilderTest extends TestCase
+{
+    private VersionBumpCommentBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new VersionBumpCommentBuilder();
+    }
+
+    public function testBuildIncludesMarkerAndAllThreeCheckboxes(): void
+    {
+        $body = $this->builder->build("feat: add dashboard");
+
+        $this->assertStringContainsString(VersionBumpCommentBuilder::MARKER, $body);
+        $this->assertStringContainsString("- [ ] " . VersionBumpCommentBuilder::CHECKBOX_MAJOR, $body);
+        $this->assertStringContainsString("- [ ] " . VersionBumpCommentBuilder::CHECKBOX_MINOR, $body);
+        $this->assertStringContainsString("- [ ] " . VersionBumpCommentBuilder::CHECKBOX_NONE, $body);
+        $this->assertStringContainsString("feat: add dashboard", $body);
+    }
+
+    public function testBuildCompletionWithoutCommitSha(): void
+    {
+        $completion = $this->builder->buildCompletion("No version bump");
+
+        $this->assertStringContainsString(VersionBumpCommentBuilder::COMPLETION_MARKER, $completion);
+        $this->assertStringContainsString("No version bump applied.", $completion);
+        $this->assertStringNotContainsString("Commit:", $completion);
+    }
+
+    public function testBuildCompletionWithCommitSha(): void
+    {
+        $completion = $this->builder->buildCompletion("Minor version bump", "abc1234");
+
+        $this->assertStringContainsString(VersionBumpCommentBuilder::COMPLETION_MARKER, $completion);
+        $this->assertStringContainsString("Minor version bump applied.", $completion);
+        $this->assertStringContainsString("Commit: `abc1234`", $completion);
+    }
+}


### PR DESCRIPTION
## 📑 Description
Introduce the ability to handle version bump decisions in pull requests. The new code analyzes pull requests for a feature-like change. If no semver directive is found, the bot comments to ask the user to choose a version bump option (major, minor, or none). The comment now acts as a decision point. When a user selects an option, it either resolves the check run (no bump) or pushes a commit with the semver directive (minor/major bump).

The main motivation is to facilitate proper semantic versioning for changes that impact features, ensuring compliance with GitVersion. The bot's comment and corresponding code improvements automate this process.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add automated version bump decision handling for feature-like pull requests and gate the pull request check run on that decision.

New Features:
- Introduce analysis of pull requests and commits to detect existing GitVersion +semver directives and whether changes look like features.
- Add bot-generated version bump decision comments with checkboxes that let maintainers select major, minor, or no version bump.
- Support applying the selected version bump by either resolving the pull request check run directly or creating a dummy commit carrying the chosen +semver directive.

Enhancements:
- Update pull request handling so the overall "GStraccini Checks: Pull Request" check run remains in progress until the version bump decision is resolved.

Tests:
- Add unit tests for version bump analysis logic and for building the decision comment and completion messages.