### PR TITLE
feat: add InstallationId support and restrict data by user +semver: minor

### DIFF
--- a/Sql/0009.add_installation_id_and_user_installations_table.sql
+++ b/Sql/0009.add_installation_id_and_user_installations_table.sql
@@ -1,0 +1,18 @@
+ALTER TABLE `notifications`
+    ADD COLUMN `InstallationId` BIGINT UNSIGNED NULL AFTER `RepositoryName`;
+
+ALTER TABLE `pending_actions`
+    ADD COLUMN `InstallationId` BIGINT UNSIGNED NULL AFTER `RepositoryName`;
+
+CREATE INDEX idx_notifications_installation_id ON notifications (`InstallationId`);
+CREATE INDEX idx_pending_actions_installation_id ON pending_actions (`InstallationId`);
+
+CREATE TABLE
+    `user_installations` (
+        `UserId` BIGINT UNSIGNED NOT NULL,
+        `InstallationId` BIGINT UNSIGNED NOT NULL,
+        `CreatedAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (`UserId`, `InstallationId`)
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_user_installations_installation_id ON user_installations (`InstallationId`);

--- a/Src/api/v1/notifications.php
+++ b/Src/api/v1/notifications.php
@@ -94,13 +94,26 @@ if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     exit;
 }
 
-$result = $mysqli->query(
-    "SELECT Sequence, RepositoryOwner, RepositoryName, Type, Title, Message, Url,
+$userId = $_GET['userId'] ?? null;
+if ($userId === null || !ctype_digit((string) $userId)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing or invalid userId']);
+    $mysqli->close();
+    exit;
+}
+$userIdInt = (int) $userId;
+
+$stmt = $mysqli->prepare(
+    "SELECT Sequence, RepositoryOwner, RepositoryName, InstallationId, Type, Title, Message, Url,
         PullRequestId, PullRequestNumber, PullRequestNodeId, IsRead, CreatedAt
      FROM notifications
      WHERE IsRead = FALSE
+        AND InstallationId IN (SELECT InstallationId FROM user_installations WHERE UserId = ?)
      ORDER BY CreatedAt DESC"
 );
+$stmt->bind_param("i", $userIdInt);
+$stmt->execute();
+$result = $stmt->get_result();
 
 $notifications = [];
 if ($result) {
@@ -109,6 +122,7 @@ if ($result) {
             'sequence' => (int) $row['Sequence'],
             'repositoryOwner' => $row['RepositoryOwner'],
             'repositoryName' => $row['RepositoryName'],
+            'installationId' => $row['InstallationId'] !== null ? (int) $row['InstallationId'] : null,
             'type' => $row['Type'],
             'title' => $row['Title'],
             'message' => $row['Message'],
@@ -123,6 +137,7 @@ if ($result) {
     $result->close();
 }
 
+$stmt->close();
 $mysqli->close();
 
 http_response_code(200);

--- a/Src/api/v1/openapi.yaml
+++ b/Src/api/v1/openapi.yaml
@@ -84,10 +84,19 @@ paths:
   /stats/:
     get:
       summary: Get usage statistics
-      description: Returns aggregate usage statistics for the bot (pull requests, commits, issues, and active repositories)
+      description: Returns aggregate usage statistics (pull requests, commits, issues, and active repositories) for the installations the given user has access to
       operationId: getStats
       tags:
         - Stats
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          description: GitHub user ID to scope statistics to (via the user's assigned installations)
+          schema:
+            type: integer
       responses:
         '200':
           description: Usage statistics
@@ -95,6 +104,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Stats'
+        '400':
+          description: Missing or invalid userId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Method not allowed
           content:
@@ -164,12 +185,19 @@ paths:
   /pending-actions/:
     get:
       summary: List unread pending actions
-      description: Returns pending actions (e.g. pull requests ready to merge) that have not yet been read
+      description: Returns pending actions (e.g. pull requests ready to merge) that have not yet been read, scoped to the installations the given user has access to
       operationId: getPendingActions
       tags:
         - Pending Actions
       security:
         - ApiKeyAuth: []
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          description: GitHub user ID to scope pending actions to (via the user's assigned installations)
+          schema:
+            type: integer
       responses:
         '200':
           description: List of unread pending actions
@@ -179,6 +207,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingAction'
+        '400':
+          description: Missing or invalid userId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Missing or invalid API key
           content:
@@ -253,12 +287,19 @@ paths:
   /notifications/:
     get:
       summary: List unread notifications
-      description: Returns notifications that have not yet been read
+      description: Returns notifications that have not yet been read, scoped to the installations the given user has access to
       operationId: getNotifications
       tags:
         - Notifications
       security:
         - ApiKeyAuth: []
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          description: GitHub user ID to scope notifications to (via the user's assigned installations)
+          schema:
+            type: integer
       responses:
         '200':
           description: List of unread notifications
@@ -268,6 +309,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Notification'
+        '400':
+          description: Missing or invalid userId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Missing or invalid API key
           content:
@@ -440,6 +487,10 @@ components:
         repositoryName:
           type: string
           example: gstraccini-bot-service
+        installationId:
+          type: integer
+          nullable: true
+          example: 12345678
         actionType:
           type: string
           example: pull_request_ready_to_merge
@@ -482,6 +533,10 @@ components:
         repositoryName:
           type: string
           example: gstraccini-bot-service
+        installationId:
+          type: integer
+          nullable: true
+          example: 12345678
         type:
           type: string
           example: pull_request_ready_to_merge

--- a/Src/api/v1/pendingActions.php
+++ b/Src/api/v1/pendingActions.php
@@ -94,13 +94,26 @@ if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     exit;
 }
 
-$result = $mysqli->query(
-    "SELECT Sequence, RepositoryOwner, RepositoryName, ActionType, Title, Description, Url,
+$userId = $_GET['userId'] ?? null;
+if ($userId === null || !ctype_digit((string) $userId)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing or invalid userId']);
+    $mysqli->close();
+    exit;
+}
+$userIdInt = (int) $userId;
+
+$stmt = $mysqli->prepare(
+    "SELECT Sequence, RepositoryOwner, RepositoryName, InstallationId, ActionType, Title, Description, Url,
         PullRequestId, PullRequestNumber, PullRequestNodeId, IsRead, CreatedAt
      FROM pending_actions
      WHERE IsRead = FALSE
+        AND InstallationId IN (SELECT InstallationId FROM user_installations WHERE UserId = ?)
      ORDER BY CreatedAt DESC"
 );
+$stmt->bind_param("i", $userIdInt);
+$stmt->execute();
+$result = $stmt->get_result();
 
 $pendingActions = [];
 if ($result) {
@@ -109,6 +122,7 @@ if ($result) {
             'sequence' => (int) $row['Sequence'],
             'repositoryOwner' => $row['RepositoryOwner'],
             'repositoryName' => $row['RepositoryName'],
+            'installationId' => $row['InstallationId'] !== null ? (int) $row['InstallationId'] : null,
             'actionType' => $row['ActionType'],
             'title' => $row['Title'],
             'description' => $row['Description'],
@@ -123,6 +137,7 @@ if ($result) {
     $result->close();
 }
 
+$stmt->close();
 $mysqli->close();
 
 http_response_code(200);

--- a/Src/api/v1/stats.php
+++ b/Src/api/v1/stats.php
@@ -16,6 +16,21 @@ if (file_exists($apiSecretsFile)) {
     require_once $apiSecretsFile;
 }
 
+$providedKey = $_SERVER['HTTP_X_API_KEY'] ?? '';
+if (empty($providedKey) || !isset($apiKey) || !hash_equals($apiKey, $providedKey)) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$userId = $_GET['userId'] ?? null;
+if ($userId === null || !ctype_digit((string) $userId)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing or invalid userId']);
+    exit;
+}
+$userIdInt = (int) $userId;
+
 if (!isset($workerDir) || !is_dir($workerDir)) {
     http_response_code(500);
     echo json_encode(['error' => 'Worker directory not configured']);
@@ -36,14 +51,26 @@ if (!isset($mySqlHost, $mySqlUser, $mySqlPassword, $mySqlDatabase)) {
 }
 
 /**
- * Run a query and return the first row, or null if the query fails
- * (e.g. the underlying table is not present).
+ * Run a query scoped to the given user's installations (via user_installations)
+ * and return the first row, or null if the query fails (e.g. the underlying
+ * table is not present).
  */
-function fetchRow(mysqli $mysqli, string $sql): ?array
+function fetchRowForUser(mysqli $mysqli, string $sql, int $userId): ?array
 {
     try {
-        $result = $mysqli->query($sql);
-        return $result ? $result->fetch_assoc() : null;
+        $stmt = $mysqli->prepare($sql);
+        if ($stmt === false) {
+            return null;
+        }
+        $placeholderCount = substr_count($sql, '?');
+        $types = str_repeat("i", $placeholderCount);
+        $params = array_fill(0, $placeholderCount, $userId);
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $row = $result ? $result->fetch_assoc() : null;
+        $stmt->close();
+        return $row;
     } catch (\mysqli_sql_exception $e) {
         return null;
     }
@@ -59,32 +86,39 @@ try {
     exit;
 }
 
-$pullRequests = fetchRow(
+$installationFilter = "InstallationId IN (SELECT InstallationId FROM user_installations WHERE UserId = ?)";
+
+$pullRequests = fetchRowForUser(
     $mysqli,
     "SELECT COUNT(*) AS total, SUM(Merged = 1) AS merged,
         ROUND(AVG(CASE WHEN Merged = 1 THEN TIMESTAMPDIFF(HOUR, CreatedAt, UpdatedAt) END), 1) AS avgMergeHours
-     FROM github_pull_requests"
+     FROM github_pull_requests
+     WHERE {$installationFilter}",
+    $userIdInt
 );
 
-$issuesClosed = fetchRow(
+$issuesClosed = fetchRowForUser(
     $mysqli,
-    "SELECT COUNT(*) AS total FROM github_issues WHERE State = 'CLOSED'"
+    "SELECT COUNT(*) AS total FROM github_issues WHERE State = 'CLOSED' AND {$installationFilter}",
+    $userIdInt
 );
 
-$commitsAnalyzed = fetchRow(
+$commitsAnalyzed = fetchRowForUser(
     $mysqli,
-    "SELECT COUNT(*) AS total FROM github_pushes"
+    "SELECT COUNT(*) AS total FROM github_pushes WHERE {$installationFilter}",
+    $userIdInt
 );
 
-$activeRepositories = fetchRow(
+$activeRepositories = fetchRowForUser(
     $mysqli,
     "SELECT COUNT(*) AS total FROM (
-        SELECT RepositoryOwner, RepositoryName FROM github_pull_requests
+        SELECT RepositoryOwner, RepositoryName FROM github_pull_requests WHERE {$installationFilter}
         UNION
-        SELECT RepositoryOwner, RepositoryName FROM github_issues
+        SELECT RepositoryOwner, RepositoryName FROM github_issues WHERE {$installationFilter}
         UNION
-        SELECT RepositoryOwner, RepositoryName FROM github_pushes
-    ) AS repos"
+        SELECT RepositoryOwner, RepositoryName FROM github_pushes WHERE {$installationFilter}
+    ) AS repos",
+    $userIdInt
 );
 
 $mysqli->close();
@@ -98,6 +132,5 @@ $stats = [
     'activeRepositories' => (int) ($activeRepositories['total'] ?? 0),
 ];
 
-header('Cache-Control: public, max-age=300');
 http_response_code(200);
 echo json_encode($stats);

--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -257,14 +257,17 @@ function createReadyToMergeAction($pullRequest, $pullRequestUpdated): void
     $title = "Pull request ready for merge/squash";
     $message = "\"{$pullRequestUpdated->title}\" (#{$pullRequestUpdated->number}) is ready ✅ for merge/squash.";
 
+    $installationId = $pullRequest->InstallationId;
+
     $sql = "INSERT INTO notifications
-        (`RepositoryOwner`, `RepositoryName`, `Type`, `Title`, `Message`, `Url`, `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        (`RepositoryOwner`, `RepositoryName`, `InstallationId`, `Type`, `Title`, `Message`, `Url`, `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     $stmt = $mysqli->prepare($sql);
     $stmt->bind_param(
-        "ssssssiis",
+        "ssissssiis",
         $pullRequest->RepositoryOwner,
         $pullRequest->RepositoryName,
+        $installationId,
         $type,
         $title,
         $message,
@@ -282,14 +285,15 @@ function createReadyToMergeAction($pullRequest, $pullRequestUpdated): void
     $stmt->close();
 
     $sql = "INSERT INTO pending_actions
-        (`NotificationSequence`, `RepositoryOwner`, `RepositoryName`, `ActionType`, `Title`, `Description`, `Url`, `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        (`NotificationSequence`, `RepositoryOwner`, `RepositoryName`, `InstallationId`, `ActionType`, `Title`, `Description`, `Url`, `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     $stmt = $mysqli->prepare($sql);
     $stmt->bind_param(
-        "issssssiis",
+        "ississssiis",
         $notificationSequence,
         $pullRequest->RepositoryOwner,
         $pullRequest->RepositoryName,
+        $installationId,
         $type,
         $title,
         $message,


### PR DESCRIPTION
## 📑 Description
Add `InstallationId` column to `notifications` and `pending_actions` tables to associate records with specific installations. Introduce `user_installations` table to map users to installation IDs. Modify APIs to require `userId` for scoping data queries using corresponding installations, enhancing data access control and improving scalability. Update OpenAPI spec to reflect new parameter requirements and error handling. This change ensures users access only relevant data by limiting scope to their installations.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Scope stats, notifications, and pending actions APIs by user installations and expose installation identifiers in responses.

New Features:
- Associate notifications and pending actions with GitHub installation IDs and persist them in the database.
- Introduce a user_installations table to map users to installations for scoping data access.
- Require userId in stats, notifications, and pending-actions endpoints to return data only for installations the user can access.

Enhancements:
- Add API key authentication and user-scoped queries to the stats endpoint.
- Include installationId fields in notifications and pending actions payloads and OpenAPI schemas.
- Update OpenAPI documentation to describe user-scoped behavior, required userId parameter, and new error responses for auth and validation failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notifications, pending actions, and statistics are now scoped to the selected user’s installations.
  - Notifications and pending actions include an installation identifier when available.
  - Added support for associating users with multiple installations.

- **API Updates**
  - User identification is now required for relevant endpoints.
  - Added validation and clearer `400`/`401` error responses.
  - Updated API documentation to reflect installation-scoped results and new response fields.

- **Bug Fixes**
  - Prevented users from seeing notifications, pending actions, or statistics unrelated to their installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->