### PR TITLE
refactor: add robust GitHub API response handling

### DIFF
--- a/Sql/0011.create_recent_activities_table.sql
+++ b/Sql/0011.create_recent_activities_table.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS `recent_activities`;
+
 CREATE TABLE
     `recent_activities` (
         `Sequence` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/Src/Handlers/PushesHandler.php
+++ b/Src/Handlers/PushesHandler.php
@@ -40,12 +40,14 @@ class PushesHandler implements IHandler
         $checkRunId = setCheckRunInProgress($metadata, $push->HeadCommitId, "commit");
         setCheckRunSucceeded($metadata, $checkRunId, "commit");
 
+        $commitSubject = strtok($push->HeadCommitMessage, "\n");
+
         recordRecentActivity(
             $push->RepositoryOwner,
             $push->RepositoryName,
             $push->InstallationId,
             "pushed_commits",
-            $push->HeadCommitMessage,
+            $commitSubject,
             "https://github.com/{$push->RepositoryOwner}/{$push->RepositoryName}/commit/{$push->HeadCommitId}"
         );
     }

--- a/Src/lib/database.php
+++ b/Src/lib/database.php
@@ -317,6 +317,8 @@ function recordRecentActivity(
 ): void {
     $mysqli = connectToDatabase();
 
+    $title = mb_substr($title, 0, 255);
+
     $sql = "INSERT INTO recent_activities
         (`RepositoryOwner`, `RepositoryName`, `InstallationId`, `ActionType`, `Title`, `Url`,
          `PullRequestId`, `PullRequestNumber`, `PullRequestNodeId`, `IssueId`, `IssueNumber`, `IssueNodeId`)

--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -10,6 +10,7 @@ use Lcobucci\JWT\Token\Builder;
 
 define("BOT_CHECK_MESSAGE_PREFIX", "GStraccini Checks: ");
 
+
 /**
  * Decodes a GitHub API JSON response body and returns the requested property.
  *

--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -14,7 +14,7 @@ define("BOT_CHECK_MESSAGE_PREFIX", "GStraccini Checks: ");
  * Decodes a GitHub API JSON response body and returns the requested property.
  *
  * @param Response $response The response returned by `doRequestGitHub`.
- * @param string $property The property to read from the decoded response body.
+ * @param string   $property The property to read from the decoded response body.
  *
  * @return mixed The value of the requested property.
  *

--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -9,6 +9,32 @@ use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token\Builder;
 
 define("BOT_CHECK_MESSAGE_PREFIX", "GStraccini Checks: ");
+
+/**
+ * Decodes a GitHub API JSON response body and returns the requested property.
+ *
+ * @param Response $response The response returned by `doRequestGitHub`.
+ * @param string $property The property to read from the decoded response body.
+ *
+ * @return mixed The value of the requested property.
+ *
+ * @throws RuntimeException When the response body is not a JSON object or does not contain the
+ * requested property (e.g. GitHub returned an error payload instead of the expected resource).
+ */
+function decodeGitHubResponse(Response $response, string $property): mixed
+{
+    $decoded = json_decode($response->getBody());
+
+    if (!is_object($decoded) || !property_exists($decoded, $property)) {
+        throw new RuntimeException(
+            "Unexpected GitHub API response: missing '{$property}' property. " .
+            "HTTP status: {$response->getStatusCode()}. Body: {$response->getBody()}"
+        );
+    }
+
+    return $decoded->$property;
+}
+
 /**
  * The function `doRequestGitHub` sends HTTP requests to the GitHub API with specified parameters and
  * handles different HTTP methods.
@@ -203,8 +229,7 @@ function generateInstallationToken(string $installationId, string $repositoryNam
 
     $url = "app/installations/" . $installationId . "/access_tokens";
     $response = doRequestGitHub($gitHubAppToken, $url, $data, "POST");
-    $json = json_decode($response->getBody());
-    return $json->token;
+    return decodeGitHubResponse($response, "token");
 }
 
 /**
@@ -232,8 +257,7 @@ function generateInstallationAccessToken(string $installationId, array $permissi
 
     $url = "app/installations/" . $installationId . "/access_tokens";
     $response = doRequestGitHub($gitHubAppToken, $url, $data, "POST");
-    $json = json_decode($response->getBody());
-    return $json->token;
+    return decodeGitHubResponse($response, "token");
 }
 
 /**
@@ -287,8 +311,7 @@ function setCheckRunInProgress(array $metadata, string $commitId, string $type):
     );
 
     $response = doRequestGitHub($metadata["token"], $metadata["checkRunUrl"], $checkRunBody, "POST");
-    $result = json_decode($response->getBody());
-    return $result->id;
+    return decodeGitHubResponse($response, "id");
 }
 
 /**
@@ -346,8 +369,7 @@ function setCheckRunQueued(array $metadata, string $commitId, string $type): int
     );
 
     $response = doRequestGitHub($metadata["token"], $metadata["checkRunUrl"], $checkRunBody, "POST");
-    $result = json_decode($response->getBody());
-    return $result->id;
+    return decodeGitHubResponse($response, "id");
 }
 
 /**


### PR DESCRIPTION
## 📑 Description
Introduce a new function `decodeGitHubResponse` to improve the handling of GitHub API responses. This function decodes the JSON response and retrieves the specified property, raising a `RuntimeException` if the response is unexpected (e.g., missing the property or not a JSON object). Update several functions (`generateInstallationToken`, `generateInstallationAccessToken`, `setCheckRunInProgress`, `setCheckRunQueued`) to use this new function, ensuring consistent error handling and clearer code.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Introduce a shared helper to decode GitHub API JSON responses and apply it across token generation and check-run helper functions for more robust error handling.

Enhancements:
- Add a decodeGitHubResponse helper to centralize JSON decoding and validation of GitHub API responses.
- Refactor installation token and check-run helper functions to use the shared decoder for consistent runtime error reporting on unexpected responses.

----
## Summary by Gitar

- **Refactoring:**
    - Introduced `decodeGitHubResponse` in `Src/lib/github.php` to centralize JSON parsing and property validation.
    - Updated `generateInstallationToken`, `generateInstallationAccessToken`, `setCheckRunInProgress`, and `setCheckRunQueued` to use the new helper.
- **Data Integrity:**
    - Truncated the `Title` field to 255 characters in `recordRecentActivity` within `Src/lib/database.php` to avoid database insertion issues.
    - Updated `PushesHandler` to extract and truncate the commit subject line before logging recent activity.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralises GitHub API response decoding into a new `decodeGitHubResponse` helper and applies it to four functions (`generateInstallationToken`, `generateInstallationAccessToken`, `setCheckRunInProgress`, `setCheckRunQueued`). It also truncates commit messages to a single subject line before logging and guards the `Title` column from overflowing its 255-character limit.

- **`Src/lib/github.php`**: New `decodeGitHubResponse` function replaces four identical inline `json_decode → property access` patterns with a single, exception-throwing helper.
- **`Src/lib/database.php`**: `mb_substr($title, 0, 255)` truncation added before the INSERT to prevent silent data truncation or DB errors.
- **`Sql/0011.create_recent_activities_table.sql`**: `DROP TABLE IF EXISTS` prepended to an already-applied migration — destructive if the script is replayed in any environment that has existing rows.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after removing the `DROP TABLE IF EXISTS` from the existing migration script; all other changes are defensive improvements.

The `decodeGitHubResponse` refactor and the `mb_substr` title guard are straightforward and correct. The one concern that needs resolution before merging is the `DROP TABLE IF EXISTS` added to the already-applied migration `0011`: re-running that script would silently destroy all rows in `recent_activities`. Removing that single line makes the PR fully safe.

`Sql/0011.create_recent_activities_table.sql` — the `DROP TABLE IF EXISTS` should be removed from this already-applied migration script.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sql/0011.create_recent_activities_table.sql | Prepends `DROP TABLE IF EXISTS` to a previously-applied migration script; silently destroys all existing `recent_activities` data if the script is re-run in any environment. |
| Src/lib/github.php | Adds `decodeGitHubResponse` helper and refactors four functions to use it; already-flagged issues (opaque JSON-parse vs. missing-property distinction, token exposure in exception message) remain open. |
| Src/Handlers/PushesHandler.php | Extracts commit subject line via `strtok`; already-flagged `false` return when message is empty/newline-only is still unaddressed. |
| Src/lib/database.php | Adds `mb_substr($title, 0, 255)` truncation before INSERT to align with the VARCHAR(255) schema limit; straightforward defensive guard. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant decodeGitHubResponse
    participant json_decode
    participant RuntimeException

    Caller->>decodeGitHubResponse: response, property
    decodeGitHubResponse->>json_decode: response.getBody()
    json_decode-->>decodeGitHubResponse: "decoded (object | null)"
    alt decoded is not object OR property missing
        decodeGitHubResponse->>RuntimeException: throw(missing property + body)
        RuntimeException-->>Caller: exception propagates
    else success
        decodeGitHubResponse-->>Caller: "decoded->property"
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["sql: recreate recent\_activities table fo..."](https://github.com/guibranco/gstraccini-bot-service/commit/ea6bb109bd98b91d147ff635b40a352fea9ddb7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46315130)</sub>

<!-- /greptile_comment -->