### PR TITLE
feat: add action_required state for version bump checks

### DIFF
--- a/Src/Handlers/CommentsHandler.php
+++ b/Src/Handlers/CommentsHandler.php
@@ -1303,7 +1303,8 @@ class CommentsHandler implements IHandler
         $checkRunName = constant("BOT_CHECK_MESSAGE_PREFIX") . "Pull Request";
 
         foreach ($result->check_runs as $checkRun) {
-            if ($checkRun->name === $checkRunName && $checkRun->status !== "completed") {
+            $isPending = $checkRun->status !== "completed" || $checkRun->conclusion === "action_required";
+            if ($checkRun->name === $checkRunName && $isPending) {
                 setCheckRunSucceeded($metadata, $checkRun->id, "pull request", $details);
             }
         }

--- a/Src/Handlers/PullRequestsHandler.php
+++ b/Src/Handlers/PullRequestsHandler.php
@@ -102,7 +102,13 @@ class PullRequestsHandler implements IHandler
             return;
         }
 
-        $checkRunId = setCheckRunInProgress($metadata, $pullRequestUpdated->head->sha, "pull request");
+        $existingCheckRun = $this->findExistingCheckRun($metadata, $pullRequestUpdated->head->sha, "pull request");
+        $alreadyActionRequired = $existingCheckRun !== null && $existingCheckRun->conclusion === "action_required";
+
+        if (!$alreadyActionRequired) {
+            $checkRunId = setCheckRunInProgress($metadata, $pullRequestUpdated->head->sha, "pull request");
+        }
+
         $this->enableAutoMerge($metadata, $pullRequest, $pullRequestUpdated, $config);
         $this->addLabelsFromIssue($metadata, $pullRequest, $pullRequestUpdated);
         $this->updateBranch($metadata, $pullRequestUpdated);
@@ -182,7 +188,9 @@ class PullRequestsHandler implements IHandler
         $this->checkDependencyChanges($metadata, $pullRequestUpdated);
 
         if ($versionBumpResolved) {
-            setCheckRunSucceeded($metadata, $checkRunId, "pull request");
+            setCheckRunSucceeded($metadata, $checkRunId ?? $existingCheckRun->id, "pull request");
+        } elseif ($alreadyActionRequired) {
+            echo "State: Version bump decision pending - check run already action_required, skipping redundant update ⚠️\n";
         } else {
             setCheckRunActionRequired(
                 $metadata,
@@ -192,6 +200,34 @@ class PullRequestsHandler implements IHandler
             );
             echo "State: Version bump decision pending - marking 'pull request' check run as action_required ⚠️\n";
         }
+    }
+
+    /**
+     * Finds the bot's existing check run of the given type for a commit sha, if any.
+     * Used to avoid re-creating and re-completing a check run on every PR event while
+     * it's already sitting in a terminal state (e.g. `action_required`) with nothing changed.
+     *
+     * @param array $metadata Metadata for the GitHub API request
+     * @param string $sha The commit sha to look up check runs for
+     * @param string $type The check type (e.g. "pull request"), used to match the check run name
+     * @return object|null The matching check run, or null if none exists yet
+     */
+    private function findExistingCheckRun(array $metadata, string $sha, string $type): ?object
+    {
+        $url = "repos/{$metadata['owner']}/{$metadata['repo']}/commits/{$sha}/check-runs";
+        $response = doRequestGitHub($metadata["token"], $url, null, "GET");
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $checkRunName = constant("BOT_CHECK_MESSAGE_PREFIX") . ucwords($type);
+        foreach (json_decode($response->getBody())->check_runs as $checkRun) {
+            if ($checkRun->name === $checkRunName) {
+                return $checkRun;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Src/Handlers/PullRequestsHandler.php
+++ b/Src/Handlers/PullRequestsHandler.php
@@ -184,7 +184,13 @@ class PullRequestsHandler implements IHandler
         if ($versionBumpResolved) {
             setCheckRunSucceeded($metadata, $checkRunId, "pull request");
         } else {
-            echo "State: Version bump decision pending - leaving 'pull request' check run in progress ⏳\n";
+            setCheckRunActionRequired(
+                $metadata,
+                $checkRunId,
+                "pull request",
+                "Waiting on a version bump decision. Check one of the boxes on the bot's comment to continue."
+            );
+            echo "State: Version bump decision pending - marking 'pull request' check run as action_required ⚠️\n";
         }
     }
 

--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -409,8 +409,8 @@ function setCheckRunSucceeded(array $metadata, int $checkRunId, string $type, st
  * conclusion, signaling that the check is blocked on a decision from the user
  * rather than still being computed.
  *
- * @param array $metadata Metadata for the GitHub API request. Must include `checkRunUrl`
- * and `dashboardUrl`.
+ * @param array $metadata Metadata for the GitHub API request. Must include `checkRunUrl`,
+ * `dashboardUrl`, and `token`.
  * @param int $checkRunId The ID of the check run to update.
  * @param string $type The check type, used to build the check run name and summary.
  * @param string $details Explanation of what the user needs to do, shown in the check output.

--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -403,3 +403,31 @@ function setCheckRunSucceeded(array $metadata, int $checkRunId, string $type, st
 
     doRequestGitHub($metadata["token"], $metadata["checkRunUrl"] . "/" . $checkRunId, $checkRunBody, "PATCH");
 }
+
+/**
+ * Updates a GitHub check run to mark it as completed with an `action_required`
+ * conclusion, signaling that the check is blocked on a decision from the user
+ * rather than still being computed.
+ *
+ * @param array $metadata Metadata for the GitHub API request. Must include `checkRunUrl`
+ * and `dashboardUrl`.
+ * @param int $checkRunId The ID of the check run to update.
+ * @param string $type The check type, used to build the check run name and summary.
+ * @param string $details Explanation of what the user needs to do, shown in the check output.
+ */
+function setCheckRunActionRequired(array $metadata, int $checkRunId, string $type, string $details): void
+{
+    $checkRunBody = array(
+        "name" => constant("BOT_CHECK_MESSAGE_PREFIX") . ucwords($type),
+        "details_url" => $metadata["dashboardUrl"],
+        "status" => "completed",
+        "conclusion" => "action_required",
+        "output" => array(
+            "title" => "Action required ⚠️",
+            "summary" => "GStraccini needs a decision from you on this " . strtolower($type) . ".",
+            "text" => $details
+        )
+    );
+
+    doRequestGitHub($metadata["token"], $metadata["checkRunUrl"] . "/" . $checkRunId, $checkRunBody, "PATCH");
+}


### PR DESCRIPTION
## 📑 Description
Introduce an `action_required` state to GitHub check runs, which applies to version bump decisions. This update allows the check to be marked as requiring user intervention when awaiting a version bump decision. The `CommentsHandler` and `PullRequestsHandler` are updated to check for pending decisions and mark these runs appropriately. This change improves clarity for users by indicating that the check is pending due to decisions to be made, not computational progress.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Mark GitHub version bump checks as requiring user action instead of leaving them in progress when waiting on a decision.

New Features:
- Add support for setting GitHub check runs to an `action_required` conclusion for version bump-related checks.

Enhancements:
- Update pull request handling to mark version bump checks as `action_required` when a decision is pending and log the new state.
- Adjust comment handling so that version bump check runs completed after a decision are resolved even if they were previously marked `action_required`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `action_required` conclusion to GitHub check runs when the bot is waiting on a version bump decision, replacing the previous behavior of leaving the check run in `in_progress` indefinitely. It also adds logic to avoid redundant API updates when the check run is already in the `action_required` state.

- **`PullRequestsHandler.php`**: Introduces `findExistingCheckRun()` to detect whether the bot's check run for the current SHA is already `action_required`, skipping the `setCheckRunInProgress` call when it is and falling through to a no-op log message instead of re-marking it on every PR event.
- **`CommentsHandler.php`**: Extends the `$isPending` condition to also match `completed/action_required` check runs so they are resolved to success when the user makes a decision.
- **`github.php`**: Adds the new `setCheckRunActionRequired()` helper that PATCHes a check run to `completed/action_required` with a user-facing message.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is logically correct across all branching paths and the new API helper mirrors the existing pattern cleanly.

All three case branches in PullRequestsHandler are correctly handled: already-action_required skips the in-progress call and the redundant update, version-bump-resolved falls back to the existing check run ID via the null-coalescing operator, and the new path correctly creates then immediately transitions the run to action_required. CommentsHandler's expanded isPending condition correctly catches the completed/action_required state without affecting other terminal conclusions.

No files require special attention; the PullRequestsHandler changes are the most involved but the logic holds up under all input combinations.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Src/Handlers/PullRequestsHandler.php | Adds findExistingCheckRun() and action_required branching; $checkRunId undefined-variable access guarded by ?? operator is safe in PHP, but the extra GET request on every PR event is a new overhead trade-off. |
| Src/Handlers/CommentsHandler.php | One-line condition change correctly expands the "pending" check to include completed/action_required check runs so they are resolved when a user acts. |
| Src/lib/github.php | New setCheckRunActionRequired() function is a clean mirror of setCheckRunSucceeded() with the correct conclusion value; no issues found. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: avoid redundant check runs and opti..."](https://github.com/guibranco/gstraccini-bot-service/commit/5c6c41e38dc589044d79579f8bbfdaea5f0f28b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46332978)</sub>

<!-- /greptile_comment -->